### PR TITLE
Fix radial basis mapper

### DIFF
--- a/coupling_components/mappers/mappers.md
+++ b/coupling_components/mappers/mappers.md
@@ -207,9 +207,9 @@ $$
 
 As every to-point has different nearest neighbours in the _from_-points, the coefficient vector $\boldsymbol{c}$ must be calculated for each _to_-point independently. The matrix $\boldsymbol{\Phi}$ and vector $\boldsymbol{\Phi}_{to}$ must also be calculated for every _to_-point independently.
 
-For every _to_-point, the reference distance $d_{ref}$ is determined as the product of the distance $d_{fur}$ of the two furthest _from_-points and the `shape_parameter`.
+For every _to_-point, the reference distance $d_{ref}$ is determined as the product of the `shape_parameter` and the distance between the _to_-point and the furthest _from_-point.
 
-In order to ensure that the basis function of each of the nearest _from_-points covers every _from_-point, the `shape_parameter` should be larger than one.
+In order to ensure that the basis function of each of the nearest _from_-points covers every _from_-point, the `shape_parameter` should be larger than two.
 This value may however lead to an interpolation function which consists of sharp peaks or wiggles, with the correct value near the _from_-points, but a deviating value away from them.
 
 In the extreme case of a very small $d_{ref}$ approaching zero, the so-called "bed-of-nails interpolant" will be obtained, which is near zero everywhere, except near the _from_-points where it will sharply peak.

--- a/coupling_components/mappers/radial_basis.py
+++ b/coupling_components/mappers/radial_basis.py
@@ -23,6 +23,8 @@ class MapperRadialBasis(MapperInterpolator):
         self.parallel = self.settings['parallel'].GetBool() if self.settings.Has('parallel') else False
         self.shape_parameter = self.settings['shape_parameter'].GetInt() if self.settings.Has('shape_parameter') \
             else 200
+        if self.shape_parameter < 2:
+            tools.Print(f'Shape parameter is {self.shape_parameter} < 2\n', layout='warning')
 
         # determine number of nearest neighbours
         if len(self.directions) == 3:

--- a/tests/mappers/test_radial_basis.py
+++ b/tests/mappers/test_radial_basis.py
@@ -19,28 +19,28 @@ class TestMapperRadialBasis(KratosUnittest.TestCase):
         # 1D case: square-root grid + linear function
         """
         n_from = 14, n_to = 5 
-            => max error = 5.8e-5
+            => max error = 6.1e-7 (sh_par 2: 5.8e-5, sh_par 1000: 1.2e-7)
         """
         n_from, n_to = 14, 5
         par_mapper['settings'].SetArray('directions', ['Z'])
 
         case = Case1D(n_from, n_to)
         case.map(par_mapper)
-        self.assertTrue(case.check(tolerance=1e-4))
+        self.assertTrue(case.check(tolerance=7e-7))
         if gui:
             case.plot()
 
         # 2D case: circle + linear function
         """
         n_from = 33, n_to = 22 
-            => max error = 0.003
+            => max error = 1.4e-5 (sh_par 2: 0.003, sh_par 1000: 2.7e-6)
         """
         n_from, n_to = 33, 22
         par_mapper['settings'].SetArray('directions', ['X', 'Y'])
 
         case = Case2D(n_from, n_to)
         case.map(par_mapper)
-        self.assertTrue(case.check(tolerance=0.005))
+        self.assertTrue(case.check(tolerance=2e-5))
         if gui:
             case.plot()
 
@@ -48,7 +48,7 @@ class TestMapperRadialBasis(KratosUnittest.TestCase):
         """
         n_theta_from, n_phi_from = 50, 30
         n_theta_to, n_phi_to = 22, 11
-            => max error = 3.2e-4
+            => max error = 1.0e-4 (sh_par 2: 3.2e-4, sh_par 1000: 1.0e-4 + warning)
         """
         n_theta_from, n_phi_from = 50, 30
         n_theta_to, n_phi_to = 22, 11
@@ -56,7 +56,7 @@ class TestMapperRadialBasis(KratosUnittest.TestCase):
 
         case = Case3DSphere(n_theta_from, n_phi_from, n_theta_to, n_phi_to)
         case.map(par_mapper)
-        self.assertTrue(case.check(tolerance=5e-4))
+        self.assertTrue(case.check(tolerance=2e-4))
         if gui:
             case.plot()
 
@@ -65,7 +65,7 @@ class TestMapperRadialBasis(KratosUnittest.TestCase):
         n_x_from, n_theta_from = 50, 15
         n_x_to, n_theta_to = 45, 13
         length = 1000.
-            => max error = 0.00047
+            => max error = 2.8e-4 (sh_par 2: 4.7-e4, sh_par 1000: 2.8e-4)
         """
         n_x_from, n_theta_from = 50, 15
         n_x_to, n_theta_to = 45, 13
@@ -76,7 +76,7 @@ class TestMapperRadialBasis(KratosUnittest.TestCase):
 
         case = Case3DCylinder(n_x_from, n_theta_from, n_x_to, n_theta_to, length)
         case.map(par_mapper)
-        self.assertTrue(case.check(tolerance=5e-4))
+        self.assertTrue(case.check(tolerance=3e-4))
         if gui:
             case.plot()
         par_mapper['settings'].RemoveValue('scaling')
@@ -85,11 +85,11 @@ class TestMapperRadialBasis(KratosUnittest.TestCase):
         """
         n_x_from, n_y_from = 20, 20
         n_x_to, n_y_to = 13, 13
-            => max error = 0.05
+            => max error = 0.0024 (sh_par 2: 0.05, sh_par 1000: 4.8e-5)
             
         n_x_from, n_y_from = 50, 50
         n_x_to, n_y_to = 60, 60
-            => max error = 0.0024
+            => max error = 7e-6 (sh_par 2: 0.0024, sh_par 1000: 1.4e-6)
         """
         n_x_from, n_y_from = 20, 20
         n_x_to, n_y_to = 13, 13
@@ -97,7 +97,7 @@ class TestMapperRadialBasis(KratosUnittest.TestCase):
 
         case = Case3DSinc(n_x_from, n_y_from, n_x_to, n_y_to)
         case.map(par_mapper)
-        for tmp in case.check(tolerance=0.1):
+        for tmp in case.check(tolerance=0.003):
             self.assertTrue(tmp)
         if gui:
             case.plot()


### PR DESCRIPTION
Add shape_parameter to settings. The reference distance d_ref = shape_parameter * d_max. A condition number check of the interpolation matrix is implemented. Documentation has been updated. 