### PR TITLE
Links in documentation

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -16,6 +16,17 @@ Some important rules for writing MD files for this documentation website:
 *   The name of the file must be unique: use names like `fluent.md` or `examples.md`, not `readme.md`.
 *   Links to other MD files: I have yet to test this... probably only works on website, not on GitHub because paths change. Possible fix: automatically replace all names `example.md` with a proper link. 
 
+### Links to other MarkDown files
+It is possible to use relative links to other MarkDown files in CoCoNuT, using the syntax
+```markdown
+[link description](relative_path)
+```
+where `relative_path` is the relative path to another MarkDown file, e.g. `../coupling_components/mappers/mappers.md`. 
+
+These links can be used in rendered MarkDown, e.g. in PyCharm, but also on GitHub itself (see [this blogpost](https://github.blog/2013-01-31-relative-links-in-markup-files/)). 
+These links also work on the documentation website, as they are automatically replaced by the correct URL. 
+Take for example a look at the documentation of the [mappers](../coupling_components/mappers/mappers.md) or the [examples](../examples/examples.md). 
+
 ### Math
 For writing mathematics, LaTeX notation can be used. Inline equations must be enclosed in single dollar signs (e.g. $E = m c^2$), block-style equations in double dolar signs, e.g.
 
@@ -23,7 +34,7 @@ $$
 e^{i \pi} + 1 = 0.
 $$
 
-LaTeX expressions will **not** be rendered on GitHub, but only on the documentation website. For the latter, the MD extension [Arithmatex](Arithmatex) is used to render the expressions with MathJax. Note that [MathJax syntax](https://math.meta.stackexchange.com/questions/5020/mathjax-basic-tutorial-and-quick-reference/) is a little more restrictive than a real LaTeX installation. 
+LaTeX expressions will **not** be rendered on GitHub, but only on the documentation website. For the latter, the MD extension [Arithmatex](https://facelessuser.github.io/pymdown-extensions/extensions/arithmatex/) is used to render the expressions with MathJax. Note that [MathJax syntax](https://math.meta.stackexchange.com/questions/5020/mathjax-basic-tutorial-and-quick-reference/) is a little more restrictive than a real LaTeX installation. 
 
 ### Images
 External images can be included with their URL. Adding locally stored images is a bit more complicated: these images must be stored in a directory `images` next to the MD file. If another location is used, they will not be shown on the website, only on GitHub. Furthermore, images must have a unique name. A warning is shown when this is not the case. 

--- a/docs/run_mkdocs.py
+++ b/docs/run_mkdocs.py
@@ -2,6 +2,8 @@ import glob
 import os
 import shutil
 from sys import argv
+import re
+import fileinput
 
 """
 README
@@ -68,6 +70,23 @@ for filename in filenames:
     used = False
 for file in unused:
     print(f'WARNING - file "{file}" is not used in mkdocs.yml')
+
+# fix links to MarkDown files
+for filename in filenames:
+    with fileinput.FileInput('docs/' + filename, inplace=True) as file:
+        for line in file:
+            matches = []
+            for match in re.finditer(r'\([a-zA-Z0-9_./\-]+\.md\)', line):
+                matches.append(match)
+            if len(matches) > 0:
+                for match in matches[::-1]:
+                    tmp = match[0][1:-4].split('/')[-1]
+                    if tmp == 'README':
+                        url = '(https://pyfsi.github.io/coconut/)'
+                    else:
+                        url = '(https://pyfsi.github.io/coconut/' + tmp + '/)'
+                    line = line[:match.start()] + url + line[match.end():]
+            print(line, end='')
 
 # find all relevant images in CoCoNuT
 extensions = ['png', 'jpg', 'jpeg']


### PR DESCRIPTION
_[from the documentation]_

It is possible to use relative links to other MarkDown files in CoCoNuT, using the syntax
```markdown
[link description](relative_path)
```
where `relative_path` is the relative path to another MarkDown file, e.g. `../coupling_components/mappers/mappers.md`. 

These links can be used in rendered MarkDown, e.g. in PyCharm, but also on GitHub itself (see [this blogpost](https://github.blog/2013-01-31-relative-links-in-markup-files/)). 
**These links also work on the documentation website, as they are automatically replaced by the correct URL.** 