### PR TITLE
Update test single solver

### DIFF
--- a/coupling_components/analysis.py
+++ b/coupling_components/analysis.py
@@ -19,7 +19,7 @@ class Analysis:
     def Initialize(self):
         self.coupled_solver.Initialize()
         self.coupled_solver.Check()
-        self.coupled_solver.PrintInfo(' ')
+        self.coupled_solver.PrintComponentsInfo(' ')
 
     def RunSolutionLoop(self):
         for _ in range(self.number_of_timesteps):

--- a/coupling_components/component.py
+++ b/coupling_components/component.py
@@ -44,5 +44,5 @@ class Component(object):
     def Check(self):
         pass
 
-    def PrintInfo(self, pre):
+    def PrintComponentsInfo(self, pre):
         tools.Print(pre, "The component ", self.__class__.__name__)

--- a/coupling_components/convergence_criteria/combined.py
+++ b/coupling_components/convergence_criteria/combined.py
@@ -1,5 +1,5 @@
 from coconut.coupling_components.component import Component
-from coconut.coupling_components.tools import CreateInstance, PrintStructureInfo
+from coconut.coupling_components.tools import CreateInstance, PrintComponentsInfo
 
 
 class ConvergenceCriterionCombined(Component):
@@ -48,10 +48,10 @@ class ConvergenceCriterionCombined(Component):
         for convergence_criterion in self.convergence_criteria:
             convergence_criterion.Check()
 
-    def PrintInfo(self, pre):
-        super().PrintInfo(pre)
+    def PrintComponentsInfo(self, pre):
+        super().PrintComponentsInfo(pre)
 
-        PrintStructureInfo(pre, self.convergence_criteria)
+        PrintComponentsInfo(pre, self.convergence_criteria)
 
     def Update(self, r):
         for convergence_criterion in self.convergence_criteria:

--- a/coupling_components/coupled_solvers/coupled_solvers.md
+++ b/coupling_components/coupled_solvers/coupled_solvers.md
@@ -7,12 +7,14 @@ An odd one out is `test_single_solver` which allows to test only one solver by c
 All coupled solvers inherit from `gauss_seidel`.
 
 In the parameter JSON file, the dictionary `coupled_solver` holds the `type` and the dictionary `settings`,
-but also `predictor`, `convergence_criterion` and `solver_wrappers`.
+but also the dictionary `predictor`, the dictionary `convergence_criterion` and the list `solver_wrappers` containing 2 dictionaries, one for each `solver_wrapper`.
 More information on these last three can be found in respectively [predictors](../predictors/predictors.md),
 [convergence_criteria](../convergence_criteria/convergence_criteria.md) and the `solver_wrappers` documentation.
 
 
 ## GaussSeidel
+
+The `type` for this `coupled_solver` is `coupled_solvers.gauss_seidel`.
 
 ### Algorithm
 
@@ -36,7 +38,7 @@ parameter|type|description
 ---:|:---:|---
 `delta_t`|double|Fixed time step size used in both solvers. For a steady simulation typically a value of 1 is taken.
 `name`|string|(optional) Name of the case used to store a pickle file with results. If not provided 'results' is used.
-`save_results`|bool|(optional) Default: false. If true a pickle file is stored containing some main results: the value of the displacement and load on the interface for every time step, interface objects used by the two solvers, the number of coupling iterations per time step, the total elapsed time for the calculation, the residual after every coupling iteration and the values of `delta_t` and `timestep_start`.<br> This file is used by the postprocessing files included with the test examples.
+`save_results`|bool|(optional) Default: false. If true a pickle file is stored containing some main results: the value of the displacement and load on the interface for every time step, interface objects used by the two solvers, the number of coupling iterations per time step, the total elapsed time for the calculation, the residual after every coupling iteration and the values of `delta_t` and `timestep_start`.<br> This file is used by the postprocessing files included with the examples.
 `time_step_start`|int|Time step number to (re)start a transient FSI calculation. If 0 is given, the simulation starts from scratch. Otherwise, the code looks for the relevant files to start from the corresponding time step. Not every solver implements restart, see the solver documentation for more information. For a steady simulation this should be 0.
 
 `timestep_start` and `delta_t` are necessary parameters (also in a steady simulation), but can also defined in the solverwrapper directly (e.g. for standalone testing).
@@ -46,7 +48,8 @@ If they are defined both here and in the solver wrapper, then the former value i
 
 ## Relaxation
 
-This coupled solvers inherits from `GaussSeidel`.
+This `coupled_solver` inherits from `GaussSeidel`.
+The `type` for this `coupled_solver` is `coupled_solvers.relaxation`.
 
 ### Algorithm
 
@@ -82,7 +85,8 @@ parameter|type|description
 
 ## Aitken
 
-This coupled solvers inherits from `GaussSeidel`.
+This `coupled_solver` inherits from `GaussSeidel`.
+The `type` for this `coupled_solver` is `coupled_solvers.aitken`.
 
 ### Algorithm
 
@@ -131,7 +135,8 @@ parameter|type|description
 
 ## IQNI
 
-This coupled solvers inherits from `GaussSeidel`.
+This `coupled_solver` inherits from `GaussSeidel`.
+The `type` for this `coupled_solver` is `coupled_solvers.iqni`.
 
 ### Algorithm
 
@@ -204,7 +209,8 @@ parameter|type|description
 
 ## IBQN
 
-This coupled solvers inherits from `GaussSeidel`.
+This `coupled_solver` inherits from `GaussSeidel`.
+The `type` for this `coupled_solver` is `coupled_solvers.ibqn`.
 
 ### Algorithm
 
@@ -282,52 +288,55 @@ parameter|type|description
 
 ## Test single solver
 
-The solver `test_single_solver` can be used to test new cases and settings.
+The solver `test_single_solver` can be used to test new cases and solver settings.
 The idea behind this component is to only test one of the two solvers, while the other one is replaced by a dummy.
 This test environment inherits from `GaussSeidel`. 
+The `type` for this `coupled_solver` is `coupled_solvers.test_single_solver`.
 
-## Settings
+### Dummy solver
 
-The JSON settings for this `test_single_solver` are largely the same as in `coupled_solvers`, namely
-the `type` and the  dictionaries  `settings`, `predictor`, `convergence_criterion` and `solver_wrappers`.
-The entry for `type` is `test_single_solver`, the `settings` that one wants to use in the actual simulation, can be kept, but are not used.
-Additionally to these directories, a mandatory directory `test_settings` has to be defined as well.
-An illustration can be found in the example [test_single_solver](../../examples/test_single_solver/test_single_solver.md.
-The possibilities for the `test_settings` directory are listed in alphabetical order below.
+To test only one solver, a dummy solver must be used.
+Such a dummy solver is implemented by a test class in the file `dummy_solver.py`, which has to be on the same folder level as `run_simulation.py`.
+Upon run-time an instance of this class is made.
+The test class requires methods of the form `calculate_<variable>(x,y,z,n)`, with `<variable>` being the variable(s) required by the tested solver, e.g. `DISPLACEMENT`, `PRESSURE` or `TRACTION`.
+How these variables are defined inside these methods, is up to the user.
+However, the methods need to return the right format: a 3-element list of floats for vector variables and a single float for scalar variables.
+Some examples are given in the example [test_single_solver](../../examples/test_single_solver/test_single_solver.md)
+The test class name is provided in the JSON settings as a string.
+If no test class is provided or the value `None` is used, zero input will be used.
+
+### Settings
+
+The JSON settings for this test environment `test_single_solver` are different from the other `coupled_solvers` in the sense that they only require 
+the `type`, which is `coupled_solvers.test_single_solver`, the dictionary `test_settings` and the list `solver_wrappers` containing at least one `solver_wrapper`.
+The possibilities for the `test_settings` dictionary are listed in alphabetical order below.
 
 parameter|type|description
 ---:|:---:|---
 `delta_t`|double|(optional) Time step size to be used in the test. Is optional as long as this value is defined in the `settings` dictionary. If a different value is defined in both dictionaries, the one defined in `test_settings` is chosen.
-`solver_index`|int|Has a value 0 or 1 and indicates the solver that one wants to test. 0 indicates the first solver wrapper that appears in the JSON-file, 1 the second wrapper.
-`test_class`|string|(optional) Refers to the class to use in the `dummy_solver.py` file in your case (for more information, see [example case](../../examples/test_single_solver/test_single_solver.md)).
-`timestep_start`|int|(optional) Time step to start from. In this test environment, this is set to 0 by default.
+`name`|string|(optional) Name of the case used to store a pickle file with results. If not provided 'results' is used. The pickle file will have the name `<name>_<test_solver_working_directory>.pickle`.
+`save_results`|bool|(optional) Default: false. If true a pickle file is stored containing some main results as in `gauss_seidel`.
+`solver_index`|int|Has a value 0 or 1 and indicates the solver that one wants to test. 0 indicates the first `solver_wrapper` that appears in the JSON-file, 1 the second one.
+`test_class`|string|(optional) Refers to the class to use in the `dummy_solver.py`. If not provided or `None`, zero input will be used.
+`timestep_start`|int|(optional) Time step to start from. If not provided the value defined in the `settings` dictionary is used. If the `settings` dictionary is not present, zero is used.
 
-Note that `test_settings` overwrites some parameters defined in `settings`. As such, these dictionaries are completely 
-independent. This allows the user to set up a normal case but instead of running a full simulation, a test can easily be 
-set up by only adding this `test_settings` dictionary and setting the `type` of `coupled_solvers` to `test_single_solver`.
+Other dictionaries, used for the actual calculation can be kept, but will not be used, with the possible exception of the `settings` dictionary.
+The `settings` dictionary is used to look up `delta_t`, `timestep_start`, `save_results` and `name` if not provided in `test_settings`.
+Note that `test_settings` has priority over the parameters defined in `settings`.
+This means a calculation can be tested, by only adding the `test_settings` dictionary and changing the `coupled_solver` type to `coupled_solvers.test_single_solver` and without altering anything else.
+An illustration can be found in the example [test_single_solver](../../examples/test_single_solver/test_single_solver.md).
 
-An attentive reader will notice that in the example case, an additional parameter `check_mapping` is defined. This 
-allows to test the mappers as well but this feature is currently not implemented and as such, this value is not used.
+The working directory of the solver is copied to a new directory with the same name and a suffix `_testX` with `X` an integer starting from 0.  
+As such, previous test solver working directories are not overwritten.
+The optional pickle file saving some results uses the name as specified by the JSON settings followed by an underscore and the solver test working directory.
+As such the pickle file always belongs to the corresponding test working directory.
 
-In your case directory where the simulation is run, a python file `dummy_solver.py` should be present that contains
-at least one `test_class`. These classes allow to define forces or displacement on your structure and acts as "second
-solver" to the problem. If this file is not present or `test_class` is not defined in `test_settings`, zero input will
-be used. If `dummy_solver.py` does not contain the `test_class` defined in `test_settings`, an error will occur.
+During run time, the norm of $x$ and $y$ are printed.
+A residual does not exist here.
+The arrays $x$ and $y$ do not have a physical meaning but are the in- and output of the solver:
+the output of a typical flow solver, for example, will contain pressure and traction components for all points.
+For the first solver in the `solver_wrappers` list, $x$ and $y$ are respectively in- and output,
+whereas for the second, $y$ is the input an $x$ the output.
+Nonetheless, these values can be useful to verify that the `solver_wrapper` runs.
 
-## Algorithm
-
-The initialization starts with checking whether or not `dummy_solver.py` is present. If not, a boolean `bool_test` is set
-to `False` and a message is printed that the input will be used. Then, the presence of `test_settings` is checked and
-the parameters are set. Note once more that the parameters in `test_settings` have priority over these defined in `settings`.
-Furthermore, only `delta_t` is of interest. Other `settings` are ignored, `timestep_start` is set to 0 and `save_results` 
-to `False`.
-
-As a next step, `delta_t` and `timestep_start` are added to the `settings` of the solver wrapper to be tested. The working
-directory is copied to a new directory with the same name and a suffix `_testX` with `X` an integer starting from 0.  
-Previous test working directories are not overwritten. The initialization finishes with informing the user that either
-the `test_class` is used to provide input or, in absence of this parameter, a zero input will be used.
-
-The `SolveSolutionStep` is fairly straightforward: if the boolean `bool_test` is true and a `test_class` was defined,
-the `SolutionStepValue` of the nodes on the `interface_input` of the solver wrapper is set to the values defined in the
-`test_class`. The `interface_output` of the solver wrapper is ignored. As such, this test environment can be considered
-as one way FSI in some way.
+The test environment `test_single_solver` tests only the `solver_wrapper` itself, no mapping is included.

--- a/coupling_components/coupled_solvers/gauss_seidel.py
+++ b/coupling_components/coupled_solvers/gauss_seidel.py
@@ -213,6 +213,6 @@ class CoupledSolverGaussSeidel(Component):
         for component in self.components:
             component.Check()
 
-    def PrintInfo(self, pre):
+    def PrintComponentsInfo(self, pre):
         tools.Print(pre, "The coupled solver ", self.__class__.__name__, " has the following components:")
-        tools.PrintStructureInfo(pre, self.components)
+        tools.PrintComponentsInfo(pre, self.components)

--- a/coupling_components/coupled_solvers/gauss_seidel.py
+++ b/coupling_components/coupled_solvers/gauss_seidel.py
@@ -112,11 +112,7 @@ class CoupledSolverGaussSeidel(Component):
 
         # Print time step
         if not self.solver_level:
-            out = f"════════════════════════════════════════════════════════════════════════════════\n" \
-                  f"\tTime step {self.n}\n" \
-                  f"════════════════════════════════════════════════════════════════════════════════\n" \
-                  f"Iteration\tNorm residual"
-            tools.Print(out)
+            self.PrintHeader()
 
         if self.save_results:
             self.residual.append([])
@@ -141,9 +137,7 @@ class CoupledSolverGaussSeidel(Component):
         self.iteration += 1
         self.convergence_criterion.Update(r)
         # Print iteration information
-        norm = np.linalg.norm(r.GetNumpyArray())
-        out = f"{self.iteration:<9d}\t{norm:<22.17e}"
-        tools.Print(' │' * self.solver_level, out)
+        self.PrintInfo(r)
 
         if self.save_results:
             self.residual[self.n - 1].append(np.linalg.norm(r.GetNumpyArray()))
@@ -206,6 +200,18 @@ class CoupledSolverGaussSeidel(Component):
         if self.solver_level == 0:
             out += f"\n╚═══════════════════════════════════════════════════════════════════════════════"
         tools.Print(out)
+
+    def PrintHeader(self):
+        header = f"════════════════════════════════════════════════════════════════════════════════\n" \
+                 f"\tTime step {self.n}\n" \
+                 f"════════════════════════════════════════════════════════════════════════════════\n" \
+                 f"Iteration\tNorm residual"
+        tools.Print(header)
+
+    def PrintInfo(self, r):
+        norm = np.linalg.norm(r.GetNumpyArray())
+        info = f"{self.iteration:<16d}{norm:<28.17e}"
+        tools.Print(' │' * self.solver_level, info)
 
     def Check(self):
         super().Check()

--- a/coupling_components/coupled_solvers/test_single_solver.py
+++ b/coupling_components/coupled_solvers/test_single_solver.py
@@ -6,13 +6,13 @@ from coconut.coupling_components.coupled_solvers.gauss_seidel import CoupledSolv
 import time
 import os
 import sys
+import numpy as np
 
 try:
     from dummy_solver import *
-    bool_test = True
+    dummy_solver_present = True
 except ImportError:
-    bool_test = False
-    print(f"No file named dummy_solver.py found, zero input will be used")
+    dummy_solver_present = False
 
 
 def Create(parameters):
@@ -26,42 +26,45 @@ class CoupledSolverTestSingleSolver(CoupledSolverGaussSeidel):
         Component.__init__(self)
 
         self.parameters = parameters
-        if "test_settings" not in self.parameters.keys():
-            raise KeyError("The coupled_solver \"test_single_solver\" requires "
-                           "\"test_settings\" which was not detected.")
+        self.settings = parameters["settings"] if self.parameters.Has("settings") else None  # settings is optional as long as the necessary parameters are in test_settings
 
-        # settings is optional as long as the necessary parameters are in test_settings
-        self.settings = parameters["settings"] if self.parameters.Has("settings") else None
-
-        self.test_settings = parameters["test_settings"]  # requires a new parameter input "test_settings"
-        self.solver_index = self.test_settings["solver_index"].GetInt()  # starts at 0
+        if "test_settings" not in self.parameters.keys():  # requires a new parameter input "test_settings"
+            raise KeyError('The coupled_solver "test_single_solver" requires "test_settings" which was not detected.')
+        self.test_settings = parameters["test_settings"]
+        self.solver_index = self.test_settings["solver_index"].GetInt()  # solver to be tested; starts at 0
         self.test_class = self.test_settings["test_class"].GetString() if self.test_settings.Has("test_class") else None
-        self.test_class = self.test_class if not self.test_class == "None" else None
+        if self.test_class == "None":
+            self.test_class = None
 
         # copy value of settings to test_settings (test_settings are prioritized)
         if self.settings is not None:
             self.test_settings.AddMissingParameters(self.settings)
 
         # delta_t and timestep_start
+        self.timestep_start = self.test_settings["timestep_start"].GetInt() if self.test_settings.Has("timestep_start")\
+            else 0
+        self.test_settings.AddEmptyValue("timestep_start")
+        self.test_settings.SetInt("timestep_start", self.timestep_start)
+        self.n = self.timestep_start
         self.delta_t = self.test_settings["delta_t"].GetDouble()
-        print(f"Using delta_t = {self.delta_t}")
+        tools.Print(f"Using delta_t = {self.delta_t} and timestep_start = {self.timestep_start}")
 
-        tools.Print("timestep_start set to 0 (Default for test_single_solver)")
-        self.n = 0
-
-        # add delta_t and timestep_start to solver_wrapper settings
+        self.predictor = DummyComponent()
+        self.convergence_criterion = DummyComponent()
+        # solver wrapper settings
         parameters = self.parameters["solver_wrappers"][self.solver_index]
         if parameters["type"].GetString() == "solver_wrappers.mapped":
             parameters = parameters["settings"]["solver_wrapper"]  # for mapped solver: the solver_wrapper itself tested
         settings = parameters["settings"]
 
-        if settings.Has("delta_t"):
-            tools.Print(f'WARNING: parameter "{"delta_t"}" is defined multiple times in JSON file', layout='warning')
-            settings.RemoveValue("delta_t")
-        settings.AddValue("delta_t", self.test_settings["delta_t"])
+        for key in ["timestep_start", "delta_t"]:  # add delta_t and timestep_start to solver_wrapper settings
+            if settings.Has(key):
+                tools.Print(f'WARNING: parameter "{key}" is defined multiple times in JSON file', layout='warning')
+                settings.RemoveValue(key)
+            settings.AddValue(key, self.test_settings[key])
 
-        settings.AddEmptyValue("timestep_start")
-        settings.SetInt("timestep_start", 0)
+        self.solver_wrapper = tools.CreateInstance(parameters)
+        self.solver_wrappers = [self.solver_wrapper]  # used for printing summary
 
         # working directory will be changed to a test_working_directory
         orig_wd = settings["working_directory"].GetString()
@@ -71,95 +74,105 @@ class CoupledSolverTestSingleSolver(CoupledSolverGaussSeidel):
         cur_wd = f"{orig_wd}_test{i}"
         settings.SetString("working_directory", cur_wd)
         os.system(f"cp -r {orig_wd} {cur_wd}")
-        print(f"{cur_wd} is the working_directory for the test\nCopying {orig_wd} to {cur_wd} \n")
-
-        self.solver_wrapper = tools.CreateInstance(parameters)
+        tools.Print(f"{cur_wd} is the working_directory for the test\nCopying {orig_wd} to {cur_wd} \n")
 
         self.components = [self.solver_wrapper]  # will only contain 1 solver wrapper
 
-        input = self.solver_wrapper.interface_input
+        interface_input = self.solver_wrapper.interface_input
         if self.test_class is None:
-            print("No test class specified")
-            for model_part_name, variable_names in input.model_parts_variables:
+            self.zero_input = True
+            tools.Print("No test class specified, zero input will be used")
+            for model_part_name, variable_names in interface_input.model_parts_variables:
                 for variable_name in variable_names.list():
                     variable = vars(data_structure)[variable_name.GetString()]
-                    if variable.Type() is "Double":
-                        print(f"\t0 is used as {variable_name.GetString()} input to {model_part_name}")
-                    elif variable.Type() is "Array":
-                        print(f"\t[0 0 0] is used as {variable_name.GetString()} input to {model_part_name}")
+                    if variable.Type() == "Double":
+                        tools.Print(f"\t0 is used as {variable_name.GetString()} input to {model_part_name}")
+                    elif variable.Type() == "Array":
+                        tools.Print(f"\t[0 0 0] is used as {variable_name.GetString()} input to {model_part_name}")
+        elif not dummy_solver_present:
+            raise FileNotFoundError(f"Test class specified, but no file named dummy_solver.py in {os.getcwd()}")
         else:
-            print(f"The functions from the class {self.test_class} will be used to calculate the following inputs:")
-            self.Test_object = getattr(sys.modules[__name__], self.test_class)
-            for model_part_name, variable_names in input.model_parts_variables:
+            self.zero_input = False
+            tools.Print(f"The functions from {self.test_class} will be used to calculate the following inputs:")
+            self.dummy_solver = getattr(sys.modules[__name__], self.test_class)()
+            for model_part_name, variable_names in interface_input.model_parts_variables:
                 for variable_name in variable_names.list():
                     variable = vars(data_structure)[variable_name.GetString()]
-                    if variable.Type() is "Double":
-                        print(f"\t{variable_name.GetString()} [Scalar] on {model_part_name}")
-                    elif variable.Type() is "Array":
-                        print(f"\t{variable_name.GetString()} [3D array] on {model_part_name}")
-        print("")
+                    if variable.Type() == "Double":
+                        tools.Print(f"\t{variable_name.GetString()} [Scalar] on {model_part_name}")
+                    elif variable.Type() == "Array":
+                        tools.Print(f"\t{variable_name.GetString()} [3D array] on {model_part_name}")
+        tools.Print()
+
+        self.x = None
+        self.y = None
+        self.iteration = None  # Iteration
+        self.solver_level = 0  # 0 is main solver (time step is printed)
 
         self.start_time = None
-        self.stop_time = None
-        self.iterations = [1]
-        self.save_results = False  # Always False
+        self.elapsed_time = None
+        self.iterations = []
+        self.save_results = self.test_settings["save_results"].GetBool() if self.test_settings.Has("save_results") \
+            else False
+        if self.save_results:
+            self.complete_solution_x = None
+            self.complete_solution_y = None
+            self.residual = []
+            self.case_name = self.test_settings["name"].GetString() if self.test_settings.Has("name") else "results"  # Case name
+            self.case_name += "_" + cur_wd
 
     def Initialize(self):
         Component.Initialize(self)
 
         self.solver_wrapper.Initialize()
-        # for component in self.components[1:]:
-        #     component.Initialize()
 
-        #
-        # # Construct mappers if required
-        # index_mapped = None
-        # index_other = None
-        # for i in range(2):
-        #     type = self.parameters["solver_wrappers"][i]["type"].GetString()
-        #     if type == "solver_wrappers.mapped":
-        #         index_mapped = i
-        #     else:
-        #         index_other = i
-        # # if index_other is None:
-        # #     raise ValueError("Not both solvers may be mapped solvers.")
-        # if index_mapped is not None:
-        #     # Construct input mapper
-        #     interface_input_from = self.solver_wrappers[index_other].GetInterfaceOutput()
-        #     self.solver_wrappers[index_mapped].SetInterfaceInput(interface_input_from)
-        #
-        #     # Construct output mapper
-        #     interface_output_to = self.solver_wrappers[index_other].GetInterfaceInput()
-        #     self.solver_wrappers[index_mapped].SetInterfaceOutput(interface_output_to)
+        # Initialize variables
+        if self.solver_index == 1:
+            self.x = self.solver_wrapper.GetInterfaceOutput()
+            self.y = self.solver_wrapper.GetInterfaceInput()
+        else:
+            self.x = self.solver_wrapper.GetInterfaceInput()
+            self.y = self.solver_wrapper.GetInterfaceOutput()
 
-        # # Initialize variables
-        # self.x = self.solver_wrappers[1].GetInterfaceOutput()
-        # self.predictor.Initialize(self.x)
-        #
-
-        self.solver_level = 0  # 0 is main solver (time step is printed)
-
+        if self.save_results:
+            self.complete_solution_x = self.x.GetNumpyArray().reshape(-1, 1)
+            self.complete_solution_y = self.y.GetNumpyArray().reshape(-1, 1)
         self.start_time = time.time()
 
     def SolveSolutionStep(self):
         interface_input = self.solver_wrapper.interface_input
-
         # Generation of the input data
-        if not self.test_class == "None" and bool_test:
+        if not self.zero_input:
             for model_part_name, variable_names in interface_input.model_parts_variables:
                 model_part = interface_input.model.GetModelPart(model_part_name)
                 for variable_name in variable_names.list():
                     variable = vars(data_structure)[variable_name.GetString()]
                     for node in model_part.Nodes:
-                        value = getattr(self.Test_object, f"calculate_{variable_name.GetString()}")(self.Test_object,
-                                                                                                    node.X0, node.Y0,
-                                                                                                    node.Z0, self.n)
+                        value = getattr(self.dummy_solver, f"calculate_{variable_name.GetString()}")(node.X0, node.Y0,
+                                                                                                     node.Z0, self.n)
                         node.SetSolutionStepValue(variable, 0, value)
+        # Store data in self.x and self.y
+        if self.solver_index == 1:
+            self.y = interface_input
+            self.x = self.solver_wrapper.SolveSolutionStep(interface_input)
+        else:
+            self.x = interface_input
+            self.y = self.solver_wrapper.SolveSolutionStep(interface_input)
+        self.FinalizeIteration(self.x * 0)
 
-        interface_output = self.solver_wrapper.SolveSolutionStep(interface_input)
+    def PrintHeader(self):
+        if self.n == self.timestep_start + 1:
+            header = f"════════════════════════════════════════════════════════════════════════════════\n" \
+                f"{'Time step':<16}{'Norm x':<28}{'Norm y':<28}"
+            tools.Print(header)
 
-    def FinalizeSolutionStep(self):
-        Component.FinalizeSolutionStep(self)
+    def PrintInfo(self, r):
+        normx = np.linalg.norm(self.x.GetNumpyArray())
+        normy = np.linalg.norm(self.y.GetNumpyArray())
+        info = f"{self.n:<16d}{normx:<28.17e}{normy:<28.17e}"
+        tools.Print(' │' * self.solver_level, info)
 
-        for component in self.components:
-            component.FinalizeSolutionStep()
+
+class DummyComponent:
+    def Update(self, x):
+        pass

--- a/coupling_components/mappers/combined.py
+++ b/coupling_components/mappers/combined.py
@@ -79,6 +79,6 @@ class MapperCombined(Component):
         for mapper in self.mappers:
             mapper.OutputSolutionStep()
 
-    def PrintInfo(self, pre):
+    def PrintComponentsInfo(self, pre):
         tools.Print(pre, "The component ", self.__class__.__name__, " combining the following mappers:")
-        tools.PrintStructureInfo(pre, self.mappers)
+        tools.PrintComponentsInfo(pre, self.mappers)

--- a/coupling_components/mappers/interface.py
+++ b/coupling_components/mappers/interface.py
@@ -54,11 +54,11 @@ class MapperInterface(Component):
         for mapper in self.mappers:
             mapper.OutputSolutionStep()
 
-    def PrintInfo(self, pre):
+    def PrintComponentsInfo(self, pre):
         tools.Print(pre, "The component ", self.__class__.__name__, " maps the following model parts:")
         pre = tools.UpdatePre(pre)
         for i, mapper in enumerate(self.mappers[:-1]):
             tools.Print(pre, f"├─ModelPart '{self.keys[i][0]}' to ModelPart '{self.keys[i][1]}' with the mapper:")
-            mapper.PrintInfo(pre + '│ └─')
+            mapper.PrintComponentsInfo(pre + '│ └─')
         tools.Print(pre, f"└─ModelPart '{self.keys[-1][0]}' to ModelPart '{self.keys[-1][1]}' with the mapper:")
-        self.mappers[-1].PrintInfo(pre + '  └─')
+        self.mappers[-1].PrintComponentsInfo(pre + '  └─')

--- a/coupling_components/solver_wrappers/mapped.py
+++ b/coupling_components/solver_wrappers/mapped.py
@@ -83,11 +83,11 @@ class SolverWrapperMapped(Component):
         self.mapper_interface_output = CreateInstance(self.settings["mapper_interface_output"])
         self.mapper_interface_output.Initialize(self.interface_output_from, self.interface_output_to)
 
-    def PrintInfo(self, pre):
+    def PrintComponentsInfo(self, pre):
         tools.Print(pre, "The component ", self.__class__.__name__, " maps the following solver wrapper:")
         pre = tools.UpdatePre(pre)
-        self.solver_wrapper.PrintInfo(pre + '├─')
+        self.solver_wrapper.PrintComponentsInfo(pre + '├─')
         tools.Print(pre, '├─', "Input mapper:")
-        self.mapper_interface_input.PrintInfo(pre + '│ └─')
+        self.mapper_interface_input.PrintComponentsInfo(pre + '│ └─')
         tools.Print(pre, '└─', "Output mapper:")
-        self.mapper_interface_output.PrintInfo(pre + '  └─')
+        self.mapper_interface_output.PrintComponentsInfo(pre + '  └─')

--- a/coupling_components/tools.py
+++ b/coupling_components/tools.py
@@ -133,7 +133,7 @@ def UpdatePre(pre):
 # PrintInfoStructure: Print information from a list of Comonents in a strucutred way
 #  @param label         Preceding text ending with '├─' or '└─'
 #  @param compent_list  List of Components from which the info is printed
-def PrintStructureInfo(pre, component_list):
+def PrintComponentsInfo(pre, component_list):
     """
     This function accepts a list of Components and print their info in a structured tree-like format as such:
     ├─Component0.PrintInfo
@@ -143,8 +143,8 @@ def PrintStructureInfo(pre, component_list):
     """
     pre = UpdatePre(pre)
     for component in component_list[:-1]:
-        component.PrintInfo(pre + '├─')
-    component_list[-1].PrintInfo(pre + '└─')
+        component.PrintComponentsInfo(pre + '├─')
+    component_list[-1].PrintComponentsInfo(pre + '└─')
 
 
 # Timer-function

--- a/examples/test_single_solver/dummy_solver.py
+++ b/examples/test_single_solver/dummy_solver.py
@@ -1,5 +1,6 @@
-#Import of utilities
 import numpy as np
+from scipy import interpolate
+import matplotlib.pyplot as plt
 
 '''This is an example of dummy_solver.py
 To use test functions for the testing of a single solver, a file with this name should be included in the working directory.
@@ -11,7 +12,7 @@ The name of the class to be used should be specified in the .json file containin
 '''
 
 
-class Simple_test():
+class SimpleTest:
     def calculate_DISPLACEMENT(self, x, y, z, n):
         """ Specify the displacement of a point on the interface relative to its original position"""
         if 0.01 < x < 0.024:
@@ -37,7 +38,7 @@ class Simple_test():
         return trac
 
 
-class Transient_test():
+class TransientTest:
     def calculate_DISPLACEMENT(self, x, y, z, n):
         """ Specify the displacement of a point on the interface relative to its original position"""
         if n < 5:
@@ -79,3 +80,74 @@ class Transient_test():
             else:
                 trac = [0, 0, 0]
         return trac
+
+
+class PythonSolverTest:
+    def calculate_DISPLACEMENT(self, x, y, z, n):
+        """ Specify the displacement of a point on the interface relative to its original position"""
+        if n < 5:
+            if 0.01 < z < 0.024:
+                disp = [0, 0.0002, 0]
+            else:
+                disp = [0, 0, 0]
+        else:
+            if 0.01 < z < 0.024:
+                disp = [0, -0.0001, 0]
+            else:
+                disp = [0, 0, 0]
+        return disp
+
+    def calculate_PRESSURE(self, x, y, z, n):
+        """ Specify the pressure on the surface"""
+        if n < 5:
+            if z > 0.01:
+                pres = 1000
+            else:
+                pres = 0
+        else:
+            if z > 0.01:
+                pres = -1000
+            else:
+                pres = 0
+        return pres
+
+    def calculate_TRACTION(self, x, y, z, n):
+        """ Specify the traction on the surface"""
+        if n < 5:
+            if z > 0.01:
+                trac = [0, 0, 100]
+            else:
+                trac = [0, 0, 0]
+        else:
+            if z > 0.01:
+                trac = [0, 100, 0]
+            else:
+                trac = [0, 0, 0]
+        return trac
+
+
+class InterpolatedData:
+    def __init__(self):
+        abscissa = np.array([-0.025, -0.02433333, -0.02366667, -0.023, -0.02233333,
+                             -0.02166667, -0.021, -0.02, -0.01666667, -0.01333333,
+                             -0.01, -0.00666667, -0.00333333,  0.,  0.00333333,
+                             0.00666667,  0.01,  0.01333333,  0.01666667,  0.02,
+                             0.02066667,  0.02133333,  0.022,  0.02266667,  0.02333333,
+                             0.024,  0.02466667])
+        y_displacement = np.array([1.16621303e-10, 1.95088490e-04, 3.60966621e-04, 4.83640889e-04,
+                                   5.66206281e-04, 6.17896253e-04, 6.48283040e-04, 6.70057566e-04,
+                                   6.78144584e-04, 6.75857193e-04, 6.74728085e-04, 6.73872500e-04,
+                                   6.73091675e-04, 6.72355520e-04, 6.71655600e-04, 6.70986983e-04,
+                                   6.70345131e-04, 6.69822764e-04, 6.70441553e-04, 6.63535153e-04,
+                                   6.52518454e-04, 6.31071264e-04, 5.92546400e-04, 5.28036801e-04,
+                                   4.27512507e-04, 2.83584753e-04, 9.96992219e-05])
+        self.interpolant = interpolate.splrep(abscissa, y_displacement, s=0)
+        plt.plot(abscissa, y_displacement)
+
+    def calculate_DISPLACEMENT(self, x, y, z, n):
+        """ Specify the displacement of a point on the interface relative to its original position"""
+        if -0.025 <= x <= 0.025:
+            disp = [0, float(interpolate.splev(x, self.interpolant, der=0)), 0]
+        else:
+            disp = [0, 0, 0]
+        return disp

--- a/examples/test_single_solver/project_parameters_mapped.json
+++ b/examples/test_single_solver/project_parameters_mapped.json
@@ -6,7 +6,6 @@
     "type": "coupled_solvers.test_single_solver",
     "test_settings": {
       "solver_index": 0,
-      "check_mapping": 0,
       "test_class": "Transient_test",
       "delta_t": 0.05
     },

--- a/examples/test_single_solver/project_parameters_mapped.json
+++ b/examples/test_single_solver/project_parameters_mapped.json
@@ -6,7 +6,7 @@
     "type": "coupled_solvers.test_single_solver",
     "test_settings": {
       "solver_index": 0,
-      "test_class": "Transient_test",
+      "test_class": "TransientTest",
       "delta_t": 0.05
     },
     "settings": {

--- a/examples/test_single_solver/test_single_solver.md
+++ b/examples/test_single_solver/test_single_solver.md
@@ -5,32 +5,27 @@ using `test_single_solver` as coupling component. For more information refer to 
 
 ## Coupling algorithm
 
-The `type` is set to `test_single_solver` and an additional required dictionary `test_settings` is added.
+The `type` is set to `coupled_solvers.test_single_solver` and an additional required dictionary `test_settings` is added.
 All other parameters in the JSON file, including the `settings` dictionary, can be set to the values that will be used in the actual coupled simulation.
-
-## Predictor
-
-The initial guess in every time step is done using the linear predictor. 
-
-## Convergence criterion
-
-The convergence criteria are set as they would be used in the fully coupled simulation. However, as a dummy solver 
-imposes a certain motion or certain forces on the `interface_input` of the tested solver wrapper regardless of the output
-of the solver wrapper, these settings are not used and hence do not matter in the test environment. 
+The `settings` dictionary is used to look up `delta_t`, `timestep_start`, `save_results` and `name` if not provided in `test_settings`.
+The other dictionaries are not used: no `predictor`,` convergence_criterion` or `mapper` are used.
 
 ## Solvers
 
-If you run this case as it is, the Fluent case and solver will be tested, as the `solver_index` is set to 0 in `test_settings`.
+If you run this case as is, the Fluent case and solver will be tested, as the `solver_index` is set to 0 in `test_settings`.
+In that case the Abaqus settings won't be used.
 The Abaqus case can easily be tested by changing this value to 1.
+Then the Fluent settings will not be used.
 The index refers to the index of the respective solver in the `solver_wrappers` list in the JSON file.
 
 ## Dummy solver
 
-Even though the presence of `dummy_solver.py` is not strictly required, it can be valuable to have a nonzero input.
-The file included in this case provides an example. It contains two classes, `Simple_test` and `Transient_test` to illustrate
-how variables can be defined based on undeformed coordinates (`x`, `y`, `z`) and time step (`n`). Note that the number 
-of classes defined is not restricted. The name of the class that one wants to use should be specified in the JSON file. 
-In this example the `Transient_test` is used.
-Each class contains three function definitions with a fixed name `calculate_VARIABLE(x,y,z,n)`, with `VARIABLE` being `DISPLACEMENT`, `PRESSURE` or `TRACTION`.
-How these variables are defined inside a function, is up to the user.
-Make sure to return the right format: a 3-element list containing floats for `DISPLACEMENT` and `TRACTION` and a scalar for `PRESSURE`.
+Even though the presence `dummy_solver.py` with a test class is not strictly required, it can be very valuable because it allows to have a non-zero input.
+The file included in this case provides an example. It contains, among others, `SimpleTest`, `TransientTest` and `InterpolatedData` to illustrate how variables can be defined based on undeformed coordinates (`x`, `y`, `z`) and time step (`n`).
+Note that the number of classes defined is not restricted.
+Also note that the `__init__()` mehtod can be used to avoid repeating the same calculations multiple times.
+The name of the class that one wants to use should be specified in the JSON file. 
+In this example the `TransientTest` is used.
+Each class contains function definitions with a pre-formatted name `calculate_VARIABLE(x,y,z,n)`, with `<variable>` being the variable(s) required by the tested solver, e.g. `DISPLACEMENT`, `PRESSURE` or `TRACTION`.
+How these variables are defined inside these methods, is up to the user.
+However, the methods need to return the right format: a 3-element list of floats for vector variables and a single float for scalar variables.


### PR DESCRIPTION
Updated the `test_single_solver`:

- An instance is created of the test class
- Error checking is made more logical
- `timestep_start` is treated similar to `delta_t`, but with default value 0
- `save_results` is implemented allowing for visualization using `Animate`
- Output during run-time has been adopted
- Printing of summary error has been fixed

New examples added to `dummy_solver`.
Updating corresponding documentation.
Changing the name of `PrintInfo()` and `PrintStructureInfo()` to `PrintComponentsInfo()` (for initial overview of components).

For testing the code I advice to use the Python solvers. Adjusting the `case_path` in `animate_example` (in postprocessing), allows for easy visualization.