### PR TITLE
New data structure abaqus test

### DIFF
--- a/coupling_components/solver_wrappers/abaqus/614.py
+++ b/coupling_components/solver_wrappers/abaqus/614.py
@@ -581,7 +581,7 @@ class SolverWrapperAbaqus614(Component):
                     line_new = ''
                     for s in contents:
                         if s.strip().startswith("inc="):
-                            numbers = re.findall("\d+", s)
+                            numbers = re.findall(r"\d+", s)
                             if (not self.subcycling) and int(numbers[0]) != 1:
                                 raise NotImplementedError(f"inc={numbers[0]}: subcycling was not requested "
                                                           f"but maxNumInc > 1.")

--- a/tests/solver_wrappers/abaqus/test_v614.py
+++ b/tests/solver_wrappers/abaqus/test_v614.py
@@ -49,8 +49,8 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         solver.finalize_solution_step()
 
         # compare output, as input hasn't changed these should be the same
-        a1 = output1_1.get_variable_data(cls.mp_name_out, 'displacement').copy()
-        a2 = output1_2.get_variable_data(cls.mp_name_out, 'displacement').copy()
+        a1 = output1_1.get_variable_data(cls.mp_name_out, 'displacement')
+        a2 = output1_2.get_variable_data(cls.mp_name_out, 'displacement')
 
         # compare
         np.testing.assert_allclose(a2, a1, rtol=1e-15)
@@ -64,9 +64,7 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
 
         # get data for solver without restart
         output_single_run = solver.get_interface_output()
-        cls.a1 = output_single_run.get_variable_data(cls.mp_name_out, 'displacement').copy()
-        cls.mean_disp_y_no_shear = np.mean(np.abs(cls.a1[:, 1]))
-        cls.mean_disp_x_no_shear = np.mean(np.abs(cls.a1[:, 0]))  # needed for 3D test case
+        cls.a1 = output_single_run.get_variable_data(cls.mp_name_out, 'displacement')
         print(f"Max disp a1: {np.max(np.abs(cls.a1), axis=0)}")
 
     def setUp(self):
@@ -109,7 +107,7 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         # compare output, as input hasn't changed these should be the same
         # get data for solver with restart
         output_restart = solver.get_interface_output()
-        self.a3 = output_restart.get_variable_data(self.mp_name_out, 'displacement').copy()
+        self.a3 = output_restart.get_variable_data(self.mp_name_out, 'displacement')
         print(f"\nMax disp a3: {np.max(np.abs(self.a3), axis=0)}")
         print(f"Max diff between a1 and a3: {np.abs(self.a1 - self.a3).max(axis=0)}")
 
@@ -148,7 +146,7 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
 
         # compare output, as input hasn't changed these should be the same
         output_4cores = solver.get_interface_output()
-        self.a4 = output_4cores.get_variable_data(self.mp_name_out, 'displacement').copy()
+        self.a4 = output_4cores.get_variable_data(self.mp_name_out, 'displacement')
         print(f"\nMax disp a4: {np.max(np.abs(self.a4), axis=0)}")
         print(f"Max diff between a1 and a4: {np.abs(self.a1 - self.a4).max(axis=0)}")
 
@@ -182,11 +180,9 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
 
         # compare output, as shear input has changed these should be different
         output_shear = solver.get_interface_output()
-        self.a5 = output_shear.get_variable_data(self.mp_name_out, 'displacement').copy()
+        self.a5 = output_shear.get_variable_data(self.mp_name_out, 'displacement')
         self.mean_disp_y_shear = np.mean(np.abs(self.a5[:, 1]))
-
-        print(f'Mean y-displacement without shear = {self.mean_disp_y_no_shear} m')
-        print(f'Mean y-displacement with shear = {self.mean_disp_y_shear} m')
+        self.mean_disp_y_no_shear = np.mean(np.abs(self.a1[:, 1]))
 
         self.assertNotAlmostEqual(self.mean_disp_y_no_shear - self.mean_disp_y_shear, 0., delta=1e-12)
 
@@ -226,8 +222,9 @@ class TestSolverWrapperAbaqus614Tube3D(TestSolverWrapperAbaqus614Tube2D):
 
         # compare output, as shear input has changed these should be different
         output_shear = solver.get_interface_output()
-        self.a5 = output_shear.get_variable_data(self.mp_name_out, 'displacement').copy()
+        self.a5 = output_shear.get_variable_data(self.mp_name_out, 'displacement')
         self.mean_disp_x_shear = np.mean(np.abs(self.a5[:, 0]))
+        self.mean_disp_x_no_shear = np.mean(np.abs(self.a1[:, 0]))
 
         print(f'Mean x-displacement without shear = {self.mean_disp_x_no_shear} m')
         print(f'Mean x-displacement with shear = {self.mean_disp_x_shear} m')

--- a/tests/solver_wrappers/abaqus/test_v614.py
+++ b/tests/solver_wrappers/abaqus/test_v614.py
@@ -112,7 +112,7 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         print(f"Max diff between a1 and a3: {np.abs(self.a1 - self.a3).max(axis=0)}")
 
         if self.dimension == 2:
-            np.testing.assert_array_equal(self.a3[2], self.a3[2] * 0.0)
+            np.testing.assert_array_equal(self.a3[:, 2], self.a3[:, 2] * 0.0)
             np.testing.assert_allclose(self.a3[:, :2], self.a1[:, :2], rtol=1e-10, atol=1e-17)
         else:
             np.testing.assert_allclose(self.a3, self.a1, rtol=1e-10, atol=1e-17)
@@ -155,7 +155,7 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         print(f"Max diff between a1 and a4: {np.abs(self.a1 - self.a4).max(axis=0)}")
 
         if self.dimension == 2:
-            np.testing.assert_array_equal(self.a4[2], self.a4[2] * 0.0)
+            np.testing.assert_array_equal(self.a4[:, 2], self.a4[:, 2] * 0.0)
             np.testing.assert_allclose(self.a4[:, :2], self.a1[:, :2], rtol=1e-10, atol=1e-17)
         else:
             np.testing.assert_allclose(self.a4, self.a1, rtol=1e-10, atol=1e-17)

--- a/tests/solver_wrappers/abaqus/test_v614.py
+++ b/tests/solver_wrappers/abaqus/test_v614.py
@@ -168,9 +168,9 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         solver = create_instance(self.parameters)
         interface_input = solver.get_interface_input()
 
-        # apply non-zero shear in shear_dir (y for 2D, x for 3D)
-        local_shear = self.shear
-        local_shear[self.shear_dir] = 5
+        # apply non-zero shear in axial_dir (y for 2D, x for 3D)
+        local_shear = self.shear.copy()
+        local_shear[self.axial_dir] = 5
 
         # give value to variables
         pressure = interface_input.get_variable_data(self.mp_name_in, 'pressure')

--- a/tests/solver_wrappers/abaqus/test_v614.py
+++ b/tests/solver_wrappers/abaqus/test_v614.py
@@ -53,7 +53,7 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         a2 = output1_2.get_variable_data(cls.mp_name_out, 'displacement').copy()
 
         # compare
-        np.testing.assert_allclose(a2, a1, rtol=1e-12)
+        np.testing.assert_allclose(a2, a1, rtol=1e-15)
 
         # step 2 to 4
         for i in range(3):
@@ -75,7 +75,15 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
             self.parameters = json.load(parameter_file)
 
     def test_restart(self):
-        # test if restart option works correctly
+        """
+        Test whether restarting at time step 2 and simulating 2 time steps yields the same displacement as when the
+        simulation is ran from time step 0 until time step 4. A constant pressure is applied and no shear, on the tube
+        examples. For the test the relative difference between displacements is checked, but it is required to also use
+        a small absolute tolerance, otherwise the test will fail in the symmetry planes (i.e. whenever one of the
+        original coordinates is 0), because those have a near-zero displacement after applying a uniform pressure an no
+        shear. This near-zero value is a noise and has large relative differences between runs, but a very low absolute
+        value, they are successfully filtered with an absolute tolerance.
+        """
 
         # create solver which restarts at time step 2
         self.parameters['settings']['timestep_start'] = 2
@@ -105,10 +113,17 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         print(f"\nMax disp a3: {np.max(np.abs(self.a3), axis=0)}")
         print(f"Max diff between a1 and a3: {np.abs(self.a1 - self.a3).max(axis=0)}")
 
-        np.testing.assert_allclose(self.a3, self.a1, rtol=0, atol=1e-12)
+        np.testing.assert_allclose(self.a3, self.a1, rtol=1e-10, atol=1e-17)
 
     def test_partitioning(self):
-        # test whether using 4 CPUs gives the same results as using a single one
+        """
+        Test whether using 4 CPUs yields the same results as using a single one. A constant pressure is applied and no
+        shear, on the tube examples. For the test the relative difference between displacements is checked, but it is
+        required to also use a small absolute tolerance, otherwise the test will fail in the symmetry planes (i.e.
+        whenever one of the original coordinates is 0), because those have a near-zero displacement after applying a
+        uniform pressure an no shear. This near-zero value is a noise and has large relative differences between runs,
+        but a very low absolute value, they are successfully filtered with an absolute tolerance.
+        """
 
         # adapt Parameters, create solver
         self.parameters['settings']['cores'] = 4
@@ -137,7 +152,7 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         print(f"\nMax disp a4: {np.max(np.abs(self.a4), axis=0)}")
         print(f"Max diff between a1 and a4: {np.abs(self.a1 - self.a4).max(axis=0)}")
 
-        np.testing.assert_allclose(self.a4, self.a1, rtol=0, atol=1e-12)
+        np.testing.assert_allclose(self.a4, self.a1, rtol=1e-10, atol=1e-17)
 
     def test_shear(self):
         # test whether shear is also applied (y is the axial direction)

--- a/tests/solver_wrappers/abaqus/test_v614.py
+++ b/tests/solver_wrappers/abaqus/test_v614.py
@@ -13,7 +13,8 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
     dimension = 2
     p = 1500
     shear = np.array([0, 0, 0])
-    shear_dir = 1   # y-direction is axial direction
+    axial_dir = 1   # y-direction is axial direction
+    radial_dirs = [0]
     mp_name_in = 'BEAMINSIDEMOVING_load_points'
     mp_name_out = 'BEAMINSIDEMOVING_nodes'
 
@@ -115,11 +116,10 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         print(f"\nMax disp a3: {np.max(np.abs(self.a3), axis=0)}")
         print(f"Max diff between a1 and a3: {np.abs(self.a1 - self.a3).max(axis=0)}")
 
-        if self.dimension == 2:
-            np.testing.assert_array_equal(self.a3[:, 2], self.a3[:, 2] * 0.0)
-            np.testing.assert_allclose(self.a3[:, :2], self.a1[:, :2], rtol=1e-10, atol=1e-17)
-        else:
-            np.testing.assert_allclose(self.a3, self.a1, rtol=1e-10, atol=1e-17)
+        indices = sorted([self.axial_dir] + self.radial_dirs)
+        a3_extra = np.delete(self.a3, indices, axis=1)
+        np.testing.assert_array_equal(a3_extra, a3_extra * 0.0)
+        np.testing.assert_allclose(self.a3[:, indices], self.a1[:, indices], rtol=1e-10, atol=1e-17)
 
     def test_partitioning(self):
         """
@@ -158,11 +158,10 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         print(f"\nMax disp a4: {np.max(np.abs(self.a4), axis=0)}")
         print(f"Max diff between a1 and a4: {np.abs(self.a1 - self.a4).max(axis=0)}")
 
-        if self.dimension == 2:
-            np.testing.assert_array_equal(self.a4[:, 2], self.a4[:, 2] * 0.0)
-            np.testing.assert_allclose(self.a4[:, :2], self.a1[:, :2], rtol=1e-10, atol=1e-17)
-        else:
-            np.testing.assert_allclose(self.a4, self.a1, rtol=1e-10, atol=1e-17)
+        indices = sorted([self.axial_dir] + self.radial_dirs)
+        a4_extra = np.delete(self.a4, indices, axis=1)
+        np.testing.assert_array_equal(a4_extra, a4_extra * 0.0)
+        np.testing.assert_allclose(self.a4[:, indices], self.a1[:, indices], rtol=1e-10, atol=1e-17)
 
     def test_shear(self):
         """
@@ -210,7 +209,8 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
 class TestSolverWrapperAbaqus614Tube3D(TestSolverWrapperAbaqus614Tube2D):
     setup_case = True
     dimension = 3
-    shear_dir = 0   # x-direction is axial direction
+    axial_dir = 0   # x-direction is axial direction
+    radial_dirs = [1, 2]
     mp_name_in = 'WALLOUTSIDE_load_points'
     mp_name_out = 'WALLOUTSIDE_nodes'
 

--- a/tests/solver_wrappers/abaqus/test_v614.py
+++ b/tests/solver_wrappers/abaqus/test_v614.py
@@ -49,12 +49,9 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         output1_2 = solver.solve_solution_step(interface_input)
         solver.finalize_solution_step()
 
-        # compare output, as input hasn't changed these should be the same
-        a1 = output1_1.get_variable_data(cls.mp_name_out, 'displacement')
-        a2 = output1_2.get_variable_data(cls.mp_name_out, 'displacement')
-
-        # compare
-        np.testing.assert_allclose(a2, a1, rtol=1e-15)
+        # save output for comparison, as input hasn't changed these should be the same
+        cls.a1_1 = output1_1.get_variable_data(cls.mp_name_out, 'displacement')
+        cls.a2_1 = output1_2.get_variable_data(cls.mp_name_out, 'displacement')
 
         # step 2 to 4
         for i in range(3):
@@ -72,6 +69,12 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         file_name = join(os.path.dirname(__file__), f'test_v614/tube{int(self.dimension)}d/parameters.json')
         with open(file_name, 'r') as parameter_file:
             self.parameters = json.load(parameter_file)
+
+    def test_repeat_iteration(self):
+        """
+        Test whether repeating the same iteration yields the same results.
+        """
+        np.testing.assert_allclose(self.a2_1, self.a1_1, rtol=1e-15)
 
     def test_restart(self):
         """
@@ -162,7 +165,9 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
             np.testing.assert_allclose(self.a4, self.a1, rtol=1e-10, atol=1e-17)
 
     def test_shear(self):
-        # test whether shear is also applied
+        """
+        Test whether shear is also applied.
+        """
 
         # create solver
         solver = create_instance(self.parameters)

--- a/tests/solver_wrappers/abaqus/test_v614.py
+++ b/tests/solver_wrappers/abaqus/test_v614.py
@@ -13,6 +13,7 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
     dimension = 2
     p = 1500
     shear = np.array([0, 0, 0])
+    shear_dir = 1   # y-direction is axial direction
     mp_name_in = 'BEAMINSIDEMOVING_load_points'
     mp_name_out = 'BEAMINSIDEMOVING_nodes'
 
@@ -161,16 +162,15 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
             np.testing.assert_allclose(self.a4, self.a1, rtol=1e-10, atol=1e-17)
 
     def test_shear(self):
-        # test whether shear is also applied (y is the axial direction)
+        # test whether shear is also applied
 
         # create solver
         solver = create_instance(self.parameters)
         interface_input = solver.get_interface_input()
 
-        if self.dimension == 2:  # define a non-zero shear in y-direction
-            local_shear = self.shear + np.array([0, 5, 0])
-        else:  # define a non-zero shear in x-direction
-            local_shear = self.shear + np.array([5, 0, 0])
+        # apply non-zero shear in shear_dir (y for 2D, x for 3D)
+        local_shear = self.shear
+        local_shear[self.shear_dir] = 5
 
         # give value to variables
         pressure = interface_input.get_variable_data(self.mp_name_in, 'pressure')
@@ -191,23 +191,17 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         # compare output, as shear input has changed these should be different
         output_shear = solver.get_interface_output()
         self.a5 = output_shear.get_variable_data(self.mp_name_out, 'displacement')
-        if self.dimension == 2:
-            self.mean_disp_y_shear = np.mean(np.abs(self.a5[:, 1]))
-            self.mean_disp_y_no_shear = np.mean(np.abs(self.a1[:, 1]))
-            print(f'Mean y-displacement without shear = {self.mean_disp_y_no_shear} m')
-            print(f'Mean y-displacement with shear = {self.mean_disp_y_shear} m')
-            self.assertNotAlmostEqual(self.mean_disp_y_no_shear - self.mean_disp_y_shear, 0., delta=1e-12)
-        else:
-            self.mean_disp_x_shear = np.mean(np.abs(self.a5[:, 0]))
-            self.mean_disp_x_no_shear = np.mean(np.abs(self.a1[:, 0]))
-            print(f'Mean x-displacement without shear = {self.mean_disp_x_no_shear} m')
-            print(f'Mean x-displacement with shear = {self.mean_disp_x_shear} m')
-            self.assertNotAlmostEqual(self.mean_disp_x_no_shear - self.mean_disp_x_shear, 0., delta=1e-12)
+        self.mean_disp_shear = np.mean(np.abs(self.a5[:, self.shear_dir]))
+        self.mean_disp_no_shear = np.mean(np.abs(self.a1[:, self.shear_dir]))
+        print(f'Mean displacement in axial direction without shear = {self.mean_disp_no_shear} m')
+        print(f'Mean displacement in axial direction with shear = {self.mean_disp_shear} m')
+        self.assertNotAlmostEqual(self.mean_disp_no_shear - self.mean_disp_shear, 0., delta=1e-12)
 
 
 class TestSolverWrapperAbaqus614Tube3D(TestSolverWrapperAbaqus614Tube2D):
     setup_case = True
     dimension = 3
+    shear_dir = 0   # x-direction is axial direction
     mp_name_in = 'WALLOUTSIDE_load_points'
     mp_name_out = 'WALLOUTSIDE_nodes'
 

--- a/tests/solver_wrappers/abaqus/test_v614.py
+++ b/tests/solver_wrappers/abaqus/test_v614.py
@@ -20,14 +20,13 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        dir_tmp = join(os.getcwd(), f'solver_wrappers/abaqus/test_v614/tube{int(cls.dimension)}d')
         if cls.setup_case:
-            dir_tmp = join(os.path.realpath(os.path.dirname(__file__)), f'test_v614/tube{int(cls.dimension)}d')
-            p_setup_abaqus = subprocess.Popen(os.path.join(dir_tmp, 'setup_abaqus.sh'), cwd=dir_tmp, shell=True)
+            p_setup_abaqus = subprocess.Popen(join(dir_tmp, 'setup_abaqus.sh'), cwd=dir_tmp, shell=True)
             p_setup_abaqus.wait()
 
         # perform reference calculation
-        file_name = join(os.path.dirname(__file__), f'test_v614/tube{int(cls.dimension)}d/parameters.json')
-        with open(file_name, 'r') as parameter_file:
+        with open(join(dir_tmp, 'parameters.json')) as parameter_file:
             parameters = json.load(parameter_file)
 
         # create the solver
@@ -67,8 +66,8 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         print(f"Max disp a1: {np.max(np.abs(cls.a1), axis=0)}")
 
     def setUp(self):
-        file_name = join(os.path.dirname(__file__), f'test_v614/tube{int(self.dimension)}d/parameters.json')
-        with open(file_name, 'r') as parameter_file:
+        dir_tmp = join(os.getcwd(), f'solver_wrappers/abaqus/test_v614/tube{int(self.dimension)}d')
+        with open(join(dir_tmp, 'parameters.json')) as parameter_file:
             self.parameters = json.load(parameter_file)
 
     def test_repeat_iteration(self):

--- a/tests/solver_wrappers/abaqus/test_v614.py
+++ b/tests/solver_wrappers/abaqus/test_v614.py
@@ -191,11 +191,15 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         # compare output, as shear input has changed these should be different
         output_shear = solver.get_interface_output()
         self.a5 = output_shear.get_variable_data(self.mp_name_out, 'displacement')
-        self.mean_disp_shear = np.mean(np.abs(self.a5[:, self.shear_dir]))
-        self.mean_disp_no_shear = np.mean(np.abs(self.a1[:, self.shear_dir]))
-        print(f'Mean displacement in axial direction without shear = {self.mean_disp_no_shear} m')
-        print(f'Mean displacement in axial direction with shear = {self.mean_disp_shear} m')
-        self.assertNotAlmostEqual(self.mean_disp_no_shear - self.mean_disp_shear, 0., delta=1e-12)
+
+        # calculate mean displacement
+        # no absolute value is used on purpose to filter out the axial displacement due to pressure only
+        self.mean_displacement_shear = np.mean(self.a5[:, self.axial_dir])
+        self.mean_displacement_no_shear = np.mean(self.a1[:, self.axial_dir])
+
+        print(f'Mean displacement in axial direction without shear = {self.mean_displacement_no_shear} m')
+        print(f'Mean displacement in axial direction with shear = {self.mean_displacement_shear} m')
+        self.assertNotAlmostEqual(self.mean_displacement_no_shear - self.mean_displacement_shear, 0., delta=1e-12)
 
 
 class TestSolverWrapperAbaqus614Tube3D(TestSolverWrapperAbaqus614Tube2D):

--- a/tests/solver_wrappers/abaqus/test_v614.py
+++ b/tests/solver_wrappers/abaqus/test_v614.py
@@ -111,7 +111,11 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         print(f"\nMax disp a3: {np.max(np.abs(self.a3), axis=0)}")
         print(f"Max diff between a1 and a3: {np.abs(self.a1 - self.a3).max(axis=0)}")
 
-        np.testing.assert_allclose(self.a3, self.a1, rtol=1e-10, atol=1e-17)
+        if self.dimension == 2:
+            np.testing.assert_array_equal(self.a3[2], self.a3[2] * 0.0)
+            np.testing.assert_allclose(self.a3[:, :2], self.a1[:, :2], rtol=1e-10, atol=1e-17)
+        else:
+            np.testing.assert_allclose(self.a3, self.a1, rtol=1e-10, atol=1e-17)
 
     def test_partitioning(self):
         """
@@ -150,7 +154,11 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         print(f"\nMax disp a4: {np.max(np.abs(self.a4), axis=0)}")
         print(f"Max diff between a1 and a4: {np.abs(self.a1 - self.a4).max(axis=0)}")
 
-        np.testing.assert_allclose(self.a4, self.a1, rtol=1e-10, atol=1e-17)
+        if self.dimension == 2:
+            np.testing.assert_array_equal(self.a4[2], self.a4[2] * 0.0)
+            np.testing.assert_allclose(self.a4[:, :2], self.a1[:, :2], rtol=1e-10, atol=1e-17)
+        else:
+            np.testing.assert_allclose(self.a4, self.a1, rtol=1e-10, atol=1e-17)
 
     def test_shear(self):
         # test whether shear is also applied (y is the axial direction)

--- a/tests/solver_wrappers/abaqus/test_v614.py
+++ b/tests/solver_wrappers/abaqus/test_v614.py
@@ -116,10 +116,10 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         print(f"\nMax disp a3: {np.max(np.abs(self.a3), axis=0)}")
         print(f"Max diff between a1 and a3: {np.abs(self.a1 - self.a3).max(axis=0)}")
 
-        indices = sorted([self.axial_dir] + self.radial_dirs)
-        a3_extra = np.delete(self.a3, indices, axis=1)
-        np.testing.assert_array_equal(a3_extra, a3_extra * 0.0)
-        np.testing.assert_allclose(self.a3[:, indices], self.a1[:, indices], rtol=1e-10, atol=1e-17)
+        indices = sorted([self.axial_dir] + self.radial_dirs)  # columns that contain non-zero data
+        a3_extra = np.delete(self.a3, indices, axis=1)  # remove columns containing data
+        np.testing.assert_array_equal(a3_extra, a3_extra * 0.0)   # if a column remains it should be all zeroes
+        np.testing.assert_allclose(self.a3[:, indices], self.a1[:, indices], rtol=1e-10, atol=1e-17)  # non-zero columns
 
     def test_partitioning(self):
         """
@@ -158,10 +158,10 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         print(f"\nMax disp a4: {np.max(np.abs(self.a4), axis=0)}")
         print(f"Max diff between a1 and a4: {np.abs(self.a1 - self.a4).max(axis=0)}")
 
-        indices = sorted([self.axial_dir] + self.radial_dirs)
-        a4_extra = np.delete(self.a4, indices, axis=1)
-        np.testing.assert_array_equal(a4_extra, a4_extra * 0.0)
-        np.testing.assert_allclose(self.a4[:, indices], self.a1[:, indices], rtol=1e-10, atol=1e-17)
+        indices = sorted([self.axial_dir] + self.radial_dirs)  # columns that contain non-zero data
+        a4_extra = np.delete(self.a4, indices, axis=1)  # remove columns containing data
+        np.testing.assert_array_equal(a4_extra, a4_extra * 0.0)   # if a column remains it should be all zeroes
+        np.testing.assert_allclose(self.a4[:, indices], self.a1[:, indices], rtol=1e-10, atol=1e-17)  # non-zero columns
 
     def test_shear(self):
         """

--- a/tests/solver_wrappers/abaqus/test_v614/tube3d/parameters.json
+++ b/tests/solver_wrappers/abaqus/test_v614/tube3d/parameters.json
@@ -6,7 +6,7 @@
     "dimensions": 3,
     "arraysize": 10e5,
     "surfaces": 1,
-    "delta_t": 2e-4,
+    "delta_t": 1e-3,
     "timestep_start": 0,
     "surfaceIDs": [
       "WALLOUTSIDE"


### PR DESCRIPTION
Updated Abaqus tests to new data structure. For some tests the tolerances were changed compared to what we did before. The 3D tests inherit from the 2D tests, but some class variables assure the correct behaviour (mainly which files to load and which columns to check in the displacement results).

@awbral I don't think it's needed to check if the last column of a1 for the 2D test is zero, because we already check it for later tests. So if a mistake would happen, these other tests would fail. Otherwise we should test it somewhere in new test_method (because I don't find any of the current test methods suitable), which seems a bit overkill.