### PR TITLE
Add method to get Model instance from Interface instance

### DIFF
--- a/data_structure/interface.py
+++ b/data_structure/interface.py
@@ -54,6 +54,14 @@ class Interface:
         return copy.deepcopy(self.__parameters)
 
     @property
+    def model(self):
+        model = Model()
+        for model_part_name in self.__model:
+            model_part = self.get_model_part(model_part_name)
+            model._Model__model_parts[model_part_name] = model_part
+        return model
+
+    @property
     def size(self):
         s = 0
         for model_part_name, variable in self.model_part_variable_pairs:

--- a/data_structure/interface.py
+++ b/data_structure/interface.py
@@ -55,11 +55,7 @@ class Interface:
 
     @property
     def model(self):
-        model = Model()
-        for model_part_name in self.__model:
-            model_part = self.get_model_part(model_part_name)
-            model._Model__model_parts[model_part_name] = model_part
-        return model
+        return self.__model
 
     @property
     def size(self):

--- a/tests/data_structure/test_interface.py
+++ b/tests/data_structure/test_interface.py
@@ -52,6 +52,24 @@ class TestInterface(unittest.TestCase):
 
         self.assertEqual(self.interface.parameters, self.parameters['interface_a'])
 
+    def test_properties(self):
+        # check model_part_variable_pairs() method
+        pairs_a = self.interface.model_part_variable_pairs
+        pairs_b = self.interface.model_part_variable_pairs
+        self.assertFalse(pairs_a is pairs_b)
+        self.assertEqual(str(pairs_a), str(pairs_b))
+
+        # check parameters() method
+        parameters_bis = self.interface.parameters
+        self.assertFalse(parameters_bis is self.parameters['interface_a'])
+        self.assertEqual(str(parameters_bis), str(self.parameters['interface_a']))
+
+        # check model() method
+        model_bis = self.interface.model
+        self.assertFalse(model_bis is self.model)
+        for mp, mp_bis in zip(self.model, model_bis):
+            self.assertTrue(mp is mp_bis)
+
     def test_model_part_variable_pairs(self):
         ref_result = [('mp1', 'pressure'), ('mp1', 'traction'), ('mp2', 'density')]
         self.assertListEqual(ref_result, self.interface.model_part_variable_pairs)

--- a/tests/data_structure/test_interface.py
+++ b/tests/data_structure/test_interface.py
@@ -66,9 +66,7 @@ class TestInterface(unittest.TestCase):
 
         # check model() method
         model_bis = self.interface.model
-        self.assertFalse(model_bis is self.model)
-        for mp, mp_bis in zip(self.model, model_bis):
-            self.assertTrue(mp is mp_bis)
+        self.assertTrue(model_bis is self.model)
 
     def test_model_part_variable_pairs(self):
         ref_result = [('mp1', 'pressure'), ('mp1', 'traction'), ('mp2', 'density')]


### PR DESCRIPTION
I added a method to get the Model out of an Interface.

For extra safety, I didn't simply return the Model, but created a new one and referenced the ModelParts, because those can't be changed, while the Model could be changed in theory... 

I also added a test for several @property methods.