### PR TITLE
Create template_stfes.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/template_stfes.md
+++ b/.github/PULL_REQUEST_TEMPLATE/template_stfes.md
@@ -1,0 +1,34 @@
+Below you can find a template that can help you with submitting the pull request.
+
+## Description
+
+Briefly describe what has been changed or improved.  
+
+#### Users' experience affected?
+
+It is useful to mention whether the change affects the users' experience (e.g. when the JSON-file needs to be adapted).
+
+#### Other parts of the code affected?
+
+If other parts of the code are affected, please notify the responsible of that part using [@mentions](https://docs.github.com/en/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams).
+
+#### Tests
+
+Have you tested the code? What did you verify?
+
+#### Related issues
+
+If the pull request closes issues, [link it](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
+
+## Checklist
+
+- [ ] Style guidelines
+    1. CoCoNuT follows [the PEP8 style guide](https://www.python.org/dev/peps/pep-0008/).
+    2. Comments should be lowercase.
+    3. Errors should start with capitals, preferably without punctuation unless it's multiple sentences.
+    4. Double quotes or single quotes for strings?	
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] New and existing unit tests pass locally with my changes
+	 


### PR DESCRIPTION
A template for pull request, mainly for the STFES developers team. I created it in the .github folder, which should make it invisible (because I think it is something we won't change often and it is more GitHub related than to the code itself). I loosely based it on examples found online, but feel free to comment if something should be added or the current template is a bit of an overkill and stuff should be removed. 

I was not able to test it, I think it has to be merged first in the master (admin rights were required to put it there directly).