### PR TITLE
Fluent fixes

### DIFF
--- a/coupling_components/solver_wrappers/fluent/v2019R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2019R1.c
@@ -74,7 +74,6 @@ DEFINE_ON_DEMAND(get_thread_ids) {
     /* read in thread thread ids, should be called early on */
 
 #if !RP_NODE
-    char tmp;
     int k;
     FILE *file;
     file = fopen("bcs.txt", "r");
@@ -86,7 +85,7 @@ DEFINE_ON_DEMAND(get_thread_ids) {
 
 #if !RP_NODE
     for (k = 0; k < n_threads; k++) {
-        fscanf(file, "%s %i", &tmp, &thread_ids[k]);
+        fscanf(file, "%*s %i", &thread_ids[k]);
     }
     fclose(file);
 #endif /* !RP_NODE */

--- a/coupling_components/solver_wrappers/fluent/v2019R1.jou
+++ b/coupling_components/solver_wrappers/fluent/v2019R1.jou
@@ -69,14 +69,19 @@ define user-defined execute-on-demand "get_thread_ids::v2019R1"
 ;   SETUP DYNAMIC MESH
 (if (= timestep_start 0)
     (begin
+        (if unsteady
+            (ti-menu-load-string "define dynamic-mesh dynamic-mesh? yes no no yes no\n")
+        )
         (do ((k 0 (+ k 1))) ((>= k (length face_threads)))
             (ti-menu-load-string (format #f "define dynamic-mesh zones create ~a
                 user-defined \"move_nodes::v2019R1\"" (list-ref face_threads k)))
         )
-        (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters motion-relaxation 1")
-        (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters residual-criteria -1")
         (if unsteady
-            (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters update-interval 1")
+            (begin
+                (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters motion-relaxation 1\n")
+                (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters residual-criteria -1\n")
+                (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters update-interval 1\n")
+            )
         )
     )
 )

--- a/coupling_components/solver_wrappers/fluent/v2019R2.c
+++ b/coupling_components/solver_wrappers/fluent/v2019R2.c
@@ -74,7 +74,6 @@ DEFINE_ON_DEMAND(get_thread_ids) {
     /* read in thread thread ids, should be called early on */
 
 #if !RP_NODE
-    char tmp;
     int k;
     FILE *file;
     file = fopen("bcs.txt", "r");
@@ -86,7 +85,7 @@ DEFINE_ON_DEMAND(get_thread_ids) {
 
 #if !RP_NODE
     for (k = 0; k < n_threads; k++) {
-        fscanf(file, "%s %i", &tmp, &thread_ids[k]);
+        fscanf(file, "%*s %i", &thread_ids[k]);
     }
     fclose(file);
 #endif /* !RP_NODE */

--- a/coupling_components/solver_wrappers/fluent/v2019R2.jou
+++ b/coupling_components/solver_wrappers/fluent/v2019R2.jou
@@ -69,14 +69,19 @@ define user-defined execute-on-demand "get_thread_ids::v2019R2"
 ;   SETUP DYNAMIC MESH
 (if (= timestep_start 0)
     (begin
+        (if unsteady
+            (ti-menu-load-string "define dynamic-mesh dynamic-mesh? yes no no yes no\n")
+        )
         (do ((k 0 (+ k 1))) ((>= k (length face_threads)))
             (ti-menu-load-string (format #f "define dynamic-mesh zones create ~a
                 user-defined \"move_nodes::v2019R2\"" (list-ref face_threads k)))
         )
-        (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters motion-relaxation 1")
-        (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters residual-criteria -1")
         (if unsteady
-            (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters update-interval 1")
+            (begin
+                (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters motion-relaxation 1\n")
+                (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters residual-criteria -1\n")
+                (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters update-interval 1\n")
+            )
         )
     )
 )

--- a/coupling_components/solver_wrappers/fluent/v2019R3.c
+++ b/coupling_components/solver_wrappers/fluent/v2019R3.c
@@ -74,7 +74,6 @@ DEFINE_ON_DEMAND(get_thread_ids) {
     /* read in thread thread ids, should be called early on */
 
 #if !RP_NODE
-    char tmp;
     int k;
     FILE *file;
     file = fopen("bcs.txt", "r");
@@ -86,7 +85,7 @@ DEFINE_ON_DEMAND(get_thread_ids) {
 
 #if !RP_NODE
     for (k = 0; k < n_threads; k++) {
-        fscanf(file, "%s %i", &tmp, &thread_ids[k]);
+        fscanf(file, "%*s %i", &thread_ids[k]);
     }
     fclose(file);
 #endif /* !RP_NODE */

--- a/coupling_components/solver_wrappers/fluent/v2019R3.jou
+++ b/coupling_components/solver_wrappers/fluent/v2019R3.jou
@@ -72,14 +72,19 @@ define user-defined execute-on-demand "get_thread_ids::v2019R3"
 ;   SETUP DYNAMIC MESH
 (if (= timestep_start 0)
     (begin
+        (if unsteady
+            (ti-menu-load-string "define dynamic-mesh dynamic-mesh? yes no no yes no\n")
+        )
         (do ((k 0 (+ k 1))) ((>= k (length face_threads)))
             (ti-menu-load-string (format #f "define dynamic-mesh zones create ~a
                 user-defined \"move_nodes::v2019R3\"" (list-ref face_threads k)))
         )
-        (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters motion-relaxation 1")
-        (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters residual-criteria -1")
         (if unsteady
-            (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters update-interval 1")
+            (begin
+                (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters motion-relaxation 1\n")
+                (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters residual-criteria -1\n")
+                (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters update-interval 1\n")
+            )
         )
     )
 )

--- a/coupling_components/solver_wrappers/fluent/v2020R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2020R1.c
@@ -74,7 +74,6 @@ DEFINE_ON_DEMAND(get_thread_ids) {
     /* read in thread thread ids, should be called early on */
 
 #if !RP_NODE
-    char tmp;
     int k;
     FILE *file;
     file = fopen("bcs.txt", "r");
@@ -86,7 +85,7 @@ DEFINE_ON_DEMAND(get_thread_ids) {
 
 #if !RP_NODE
     for (k = 0; k < n_threads; k++) {
-        fscanf(file, "%s %i", &tmp, &thread_ids[k]);
+        fscanf(file, "%*s %i", &thread_ids[k]);
     }
     fclose(file);
 #endif /* !RP_NODE */

--- a/coupling_components/solver_wrappers/fluent/v2020R1.jou
+++ b/coupling_components/solver_wrappers/fluent/v2020R1.jou
@@ -69,14 +69,19 @@ define user-defined execute-on-demand "get_thread_ids::v2020R1"
 ;   SETUP DYNAMIC MESH
 (if (= timestep_start 0)
     (begin
+        (if unsteady
+            (ti-menu-load-string "define dynamic-mesh dynamic-mesh? yes no no yes no\n")
+        )
         (do ((k 0 (+ k 1))) ((>= k (length face_threads)))
             (ti-menu-load-string (format #f "define dynamic-mesh zones create ~a
                 user-defined \"move_nodes::v2020R1\"" (list-ref face_threads k)))
         )
-        (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters motion-relaxation 1")
-        (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters residual-criteria -1")
         (if unsteady
-            (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters update-interval 1")
+            (begin
+                (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters motion-relaxation 1\n")
+                (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters residual-criteria -1\n")
+                (ti-menu-load-string "define dynamic-mesh controls implicit-update-parameters update-interval 1\n")
+            )
         )
     )
 )

--- a/tests/solver_wrappers/fluent/test_v2019R1.py
+++ b/tests/solver_wrappers/fluent/test_v2019R1.py
@@ -131,8 +131,8 @@ class TestSolverWrapperFluent2019R1Tube2D(unittest.TestCase):
         solver.finalize()
 
         # check if same position gives same pressure & traction
-        np.testing.assert_allclose(pressure[0], pressure[2], rtol=1e-12)
-        np.testing.assert_allclose(traction[0], traction[2], rtol=1e-12)
+        np.testing.assert_allclose(pressure[0], pressure[2], rtol=1e-10)
+        np.testing.assert_allclose(traction[0], traction[2], rtol=1e-11)
 
         # check if different position gives different pressure & traction
         p01 = np.linalg.norm(pressure[0] - pressure[1])


### PR DESCRIPTION
Some small changes have been made:
1) The get_thread_ids function in the UDF has been adjusted to solve issue #88, there is no variable anymore where the strings in bcs.txt are stored, instead the strings are discarded as they are unneeded.
2) The journal files had some commands that are invalid for steady cases, so those have been placed in an if-clause. It is also made sure that 'implicit update' is activated for transient cases, for when the user would forget this. This situation results in erronuous behavior but the cause may be unclear to the user.
3) The thresholds for the test `TestSolverWrapperFluent2019R1Tube2D.test_pressure_traction` have been increased because there is a machine dependency, I noticed that the test fails on cfdclu58 but works on cfdclu17. This is because the maximal numbers of cores is used (such that the test is quick) and the flow convergence is checked only 10 iterations. In this test this can result in two simulations having different convergence. As their results are compared, the test failed with the previous threshold.

I ran the tube_fluent2d_abaqus2D_steady and tube_fluent2d_abaqus2d to see if the changes in the journal file solved the warnings about invalid commands. I also once disabled 'implicit update' in tube_fluent2d_abaqus2d and now the wrapper indeed deals with it. I also compared the convergence history of tube_fluent2d_tube_structure between the master and this branch.

**Checklist**
- [ ] Style guidelines
- [ ] Self-review of code performed
- [ ] Code has been commented (particularly in hard-to-understand areas)
- [ ] Documentation was updated correspondingly
- [ ] New and existing unit tests pass locally with changes
