### PR TITLE
Fluent: let user provide data file

### DIFF
--- a/coupling_components/coupled_solvers/gauss_seidel.py
+++ b/coupling_components/coupled_solvers/gauss_seidel.py
@@ -141,7 +141,7 @@ class CoupledSolverGaussSeidel(Component):
 
         # update save results
         if self.save_results:
-            self.residual[self.time_step - 1].append(r.norm())
+            self.residual[self.time_step - self.timestep_start - 1].append(r.norm())
             if self.debug:
                 self.complete_solution_x = np.hstack((self.complete_solution_x, self.x.get_interface_data().reshape(-1, 1)))
                 self.complete_solution_y = np.hstack((self.complete_solution_y, self.y.get_interface_data().reshape(-1, 1)))

--- a/coupling_components/solver_wrappers/fluent/development_tests/parameters.json
+++ b/coupling_components/solver_wrappers/fluent/development_tests/parameters.json
@@ -44,7 +44,6 @@
     "cores": 2,
     "fluent_gui": true,
     "max_nodes_per_face": 4,
-    "hybrid_initialization": true,
     "flow_iterations": 10,
     "save_iterations": 1
   }

--- a/coupling_components/solver_wrappers/fluent/v2019R1.jou
+++ b/coupling_components/solver_wrappers/fluent/v2019R1.jou
@@ -47,7 +47,7 @@ file start-transcript "transcript.txt"
 ;   READ CASE/DATA, COMPILE AND LOAD UDF
 (if (= timestep_start 0)
     (begin
-        (ti-menu-load-string "file read-case |CASE|")
+        (ti-menu-load-string "file read-case-data |CASE|")
         (ti-menu-load-string "solve set expert y n y")
         (rp-var-define 'udf/timestep 0 'int #f)
         (rp-var-define 'udf/iteration 0 'int #f)
@@ -87,22 +87,8 @@ define user-defined execute-on-demand "get_thread_ids::v2019R1"
 )
 ;
 ;   STORE COORDINATES AND IDS
-;(if (= timestep_start 0)
-;    (begin
-;        (ti-menu-load-string "define user-defined execute-on-demand \"store_coordinates_id::v2019R1\"")
-;        (send_message "nodes_and_faces_stored")
-;    )
-;)
 define user-defined execute-on-demand "store_coordinates_id::v2019R1"
 (send_message "nodes_and_faces_stored")
-;
-;   INITIALIZE SOLUTION
-(if (= timestep_start 0)
-    (if |HYBRID_INITIALIZATION|
-        (ti-menu-load-string "solve initialize hyb-initialization")
-        (ti-menu-load-string "solve initialize initialize-flow")
-    )
-)
 ;
 ;   SET DELTA_T
 (if unsteady

--- a/coupling_components/solver_wrappers/fluent/v2019R1.jou
+++ b/coupling_components/solver_wrappers/fluent/v2019R1.jou
@@ -87,8 +87,12 @@ define user-defined execute-on-demand "get_thread_ids::v2019R1"
 )
 ;
 ;   STORE COORDINATES AND IDS
-define user-defined execute-on-demand "store_coordinates_id::v2019R1"
-(send_message "nodes_and_faces_stored")
+(if (= timestep_start 0)
+    (begin
+        (ti-menu-load-string "define user-defined execute-on-demand \"store_coordinates_id::v2019R1\"")
+        (send_message "nodes_and_faces_stored")
+    )
+)
 ;
 ;   SET DELTA_T
 (if unsteady

--- a/coupling_components/solver_wrappers/fluent/v2019R1.py
+++ b/coupling_components/solver_wrappers/fluent/v2019R1.py
@@ -33,8 +33,13 @@ class SolverWrapperFluent2019R1(Component):
         if self.cores < 1 or self.cores > multiprocessing.cpu_count():
             self.cores = multiprocessing.cpu_count()  # TODO: add this behavior to documentation
         self.case_file = self.settings['case_file']
+        parts = self.case_file.split('.')
+        parts = ['dat' if part == 'cas' else part for part in parts]
+        self.data_file = '.'.join(parts)
         if not os.path.exists(os.path.join(self.dir_cfd, self.case_file)):
             raise FileNotFoundError(f'Case file {self.case_file} not found in working directory {self.dir_cfd}')
+        elif not os.path.exists(os.path.join(self.dir_cfd, self.data_file)):
+            raise FileNotFoundError(f'Data file {self.data_file} not found in working directory {self.dir_cfd}')
         self.mnpf = self.settings['max_nodes_per_face']
         self.dimensions = self.settings['dimensions']
         self.unsteady = self.settings['unsteady']

--- a/coupling_components/solver_wrappers/fluent/v2019R1.py
+++ b/coupling_components/solver_wrappers/fluent/v2019R1.py
@@ -248,9 +248,9 @@ class SolverWrapperFluent2019R1(Component):
             for dct in self.interface_input.parameters:
                 mp_name = dct['model_part']
                 thread_id = self.model_part_thread_ids[mp_name]
-                src = f"nodes_update_timestep{self.timestep}_thread{thread_id}.dat"
-                dst = f"nodes_update_timestep{self.timestep}_thread{thread_id}_Iter{self.iteration}.dat"
-                cmd = f"cp {join(self.dir_cfd, src)} {join(self.dir_cfd, dst)}"
+                src = f'nodes_update_timestep{self.timestep}_thread{thread_id}.dat'
+                dst = f'nodes_update_timestep{self.timestep}_thread{thread_id}_Iter{self.iteration}.dat'
+                cmd = f'cp {join(self.dir_cfd, src)} {join(self.dir_cfd, dst)}'
                 os.system(cmd)
 
         # let Fluent run, wait for data
@@ -272,12 +272,12 @@ class SolverWrapperFluent2019R1(Component):
             # copy output data for debugging
             if self.debug:  # TODO: Iter --> iter everywhere?
                 dst = f'pressure_traction_timestep{self.timestep}_thread{thread_id}_Iter{self.iteration}.dat'
-                cmd = f"cp {file_name} {join(self.dir_cfd, dst)}"
+                cmd = f'cp {file_name} {join(self.dir_cfd, dst)}'
                 os.system(cmd)
 
             # get face coordinates and ids
             traction_tmp = np.zeros((data.shape[0], 3)) * 0.
-            traction_tmp[:, :self.dimensions] = data[:,:-1 - self.mnpf]
+            traction_tmp[:, :self.dimensions] = data[:, :-1 - self.mnpf]
             pressure_tmp = data[:, self.dimensions].reshape(-1, 1)
             ids_tmp = self.get_unique_face_ids(data[:, -self.mnpf:])
 
@@ -445,19 +445,19 @@ class SolverWrapperFluent2019R1(Component):
         return coord_data
 
     def send_message(self, message):
-        file = join(self.dir_cfd, message + ".coco")
+        file = join(self.dir_cfd, message + '.coco')
         open(file, 'w').close()
         return
 
     def wait_message(self, message):
-        file = join(self.dir_cfd, message + ".coco")
+        file = join(self.dir_cfd, message + '.coco')
         while not os.path.isfile(file):
             time.sleep(0.01)
         os.remove(file)
         return
 
     def check_message(self, message):
-        file = join(self.dir_cfd, message + ".coco")
+        file = join(self.dir_cfd, message + '.coco')
         if os.path.isfile(file):
             os.remove(file)
             return True

--- a/coupling_components/solver_wrappers/fluent/v2019R1.py
+++ b/coupling_components/solver_wrappers/fluent/v2019R1.py
@@ -38,7 +38,6 @@ class SolverWrapperFluent2019R1(Component):
         self.mnpf = self.settings['max_nodes_per_face']
         self.dimensions = self.settings['dimensions']
         self.unsteady = self.settings['unsteady']
-        self.hybrid_initialization = self.settings['hybrid_initialization']
         self.flow_iterations = self.settings['flow_iterations']
         self.delta_t = self.settings['delta_t']
         self.timestep_start = self.settings['timestep_start']
@@ -58,16 +57,12 @@ class SolverWrapperFluent2019R1(Component):
         unsteady = '#f'
         if self.unsteady:
             unsteady = '#t'
-        hybrid_initialization = '#f'
-        if self.hybrid_initialization:
-            hybrid_initialization = '#t'
         with open(join(self.dir_src, journal)) as infile:
             with open(join(self.dir_cfd, journal), 'w') as outfile:
                 for line in infile:
                     line = line.replace('|CASE|', join(self.dir_cfd, self.case_file))
                     line = line.replace('|THREAD_NAMES|', thread_names_str)
                     line = line.replace('|UNSTEADY|', unsteady)
-                    line = line.replace('|HYBRID_INITIALIZATION|', hybrid_initialization)
                     line = line.replace('|FLOW_ITERATIONS|', str(self.flow_iterations))
                     line = line.replace('|DELTA_T|', str(self.delta_t))
                     line = line.replace('|TIMESTEP_START|', str(self.timestep_start))

--- a/coupling_components/solver_wrappers/fluent/v2019R1.py
+++ b/coupling_components/solver_wrappers/fluent/v2019R1.py
@@ -138,8 +138,9 @@ class SolverWrapperFluent2019R1(Component):
                 file.write(line + '\n')
         self.send_message('thread_ids_written_to_file')
 
-        # import node and face information (use old files on restart!)
-        self.wait_message('nodes_and_faces_stored')  # TODO: check what happens in journal
+        # import node and face information if no restart
+        if self.timestep_start == 0:
+            self.wait_message('nodes_and_faces_stored')
 
         # create Model
         self.model = data_structure.Model()
@@ -291,7 +292,7 @@ class SolverWrapperFluent2019R1(Component):
             model_part = self.model.get_model_part(mp_name)
             if ids.size != model_part.size:
                 raise ValueError('size of data does not match size of ModelPart')
-            if not (ids == model_part.id).all():
+            if not np.all(ids == model_part.id):
                 raise ValueError('IDs of data do not match ModelPart IDs')
 
             self.interface_output.set_variable_data(mp_name, 'traction', traction)

--- a/coupling_components/solver_wrappers/fluent/v2019R1.py
+++ b/coupling_components/solver_wrappers/fluent/v2019R1.py
@@ -33,9 +33,7 @@ class SolverWrapperFluent2019R1(Component):
         if self.cores < 1 or self.cores > multiprocessing.cpu_count():
             self.cores = multiprocessing.cpu_count()  # TODO: add this behavior to documentation
         self.case_file = self.settings['case_file']
-        parts = self.case_file.split('.')
-        parts = ['dat' if part == 'cas' else part for part in parts]
-        self.data_file = '.'.join(parts)
+        self.data_file = self.case_file.replace('.cas', '.dat', 1)
         if not os.path.exists(os.path.join(self.dir_cfd, self.case_file)):
             raise FileNotFoundError(f'Case file {self.case_file} not found in working directory {self.dir_cfd}')
         elif not os.path.exists(os.path.join(self.dir_cfd, self.data_file)):

--- a/coupling_components/solver_wrappers/fluent/v2019R2.jou
+++ b/coupling_components/solver_wrappers/fluent/v2019R2.jou
@@ -47,7 +47,7 @@ file start-transcript "transcript.txt"
 ;   READ CASE/DATA, COMPILE AND LOAD UDF
 (if (= timestep_start 0)
     (begin
-        (ti-menu-load-string "file read-case |CASE|")
+        (ti-menu-load-string "file read-case-data |CASE|")
         (ti-menu-load-string "solve set expert y n y")
         (rp-var-define 'udf/timestep 0 'int #f)
         (rp-var-define 'udf/iteration 0 'int #f)
@@ -87,22 +87,8 @@ define user-defined execute-on-demand "get_thread_ids::v2019R2"
 )
 ;
 ;   STORE COORDINATES AND IDS
-;(if (= timestep_start 0)
-;    (begin
-;        (ti-menu-load-string "define user-defined execute-on-demand \"store_coordinates_id::v2019R2\"")
-;        (send_message "nodes_and_faces_stored")
-;    )
-;)
 define user-defined execute-on-demand "store_coordinates_id::v2019R2"
 (send_message "nodes_and_faces_stored")
-;
-;   INITIALIZE SOLUTION
-(if (= timestep_start 0)
-    (if |HYBRID_INITIALIZATION|
-        (ti-menu-load-string "solve initialize hyb-initialization")
-        (ti-menu-load-string "solve initialize initialize-flow")
-    )
-)
 ;
 ;   SET DELTA_T
 (if unsteady

--- a/coupling_components/solver_wrappers/fluent/v2019R2.jou
+++ b/coupling_components/solver_wrappers/fluent/v2019R2.jou
@@ -87,8 +87,12 @@ define user-defined execute-on-demand "get_thread_ids::v2019R2"
 )
 ;
 ;   STORE COORDINATES AND IDS
-define user-defined execute-on-demand "store_coordinates_id::v2019R2"
-(send_message "nodes_and_faces_stored")
+(if (= timestep_start 0)
+    (begin
+        (ti-menu-load-string "define user-defined execute-on-demand \"store_coordinates_id::v2019R2\"")
+        (send_message "nodes_and_faces_stored")
+    )
+)
 ;
 ;   SET DELTA_T
 (if unsteady

--- a/coupling_components/solver_wrappers/fluent/v2019R3.jou
+++ b/coupling_components/solver_wrappers/fluent/v2019R3.jou
@@ -47,7 +47,7 @@ file start-transcript "transcript.txt"
 ;   READ CASE/DATA, COMPILE AND LOAD UDF
 (if (= timestep_start 0)
     (begin
-        (ti-menu-load-string "file read-case |CASE|")
+        (ti-menu-load-string "file read-case-data |CASE|")
         (ti-menu-load-string "solve set expert y n y")
         (rp-var-define 'udf/timestep 0 'int #f)
         (rp-var-define 'udf/iteration 0 'int #f)
@@ -90,22 +90,8 @@ define user-defined execute-on-demand "get_thread_ids::v2019R3"
 )
 ;
 ;   STORE COORDINATES AND IDS
-;(if (= timestep_start 0)
-;    (begin
-;        (ti-menu-load-string "define user-defined execute-on-demand \"store_coordinates_id::v2019R3\"")
-;        (send_message "nodes_and_faces_stored")
-;    )
-;)
 define user-defined execute-on-demand "store_coordinates_id::v2019R3"
 (send_message "nodes_and_faces_stored")
-;
-;   INITIALIZE SOLUTION
-(if (= timestep_start 0)
-    (if |HYBRID_INITIALIZATION|
-        (ti-menu-load-string "solve initialize hyb-initialization")
-        (ti-menu-load-string "solve initialize initialize-flow")
-    )
-)
 ;
 ;   SET DELTA_T
 (if unsteady

--- a/coupling_components/solver_wrappers/fluent/v2019R3.jou
+++ b/coupling_components/solver_wrappers/fluent/v2019R3.jou
@@ -90,8 +90,12 @@ define user-defined execute-on-demand "get_thread_ids::v2019R3"
 )
 ;
 ;   STORE COORDINATES AND IDS
-define user-defined execute-on-demand "store_coordinates_id::v2019R3"
-(send_message "nodes_and_faces_stored")
+(if (= timestep_start 0)
+    (begin
+        (ti-menu-load-string "define user-defined execute-on-demand \"store_coordinates_id::v2019R3\"")
+        (send_message "nodes_and_faces_stored")
+    )
+)
 ;
 ;   SET DELTA_T
 (if unsteady

--- a/coupling_components/solver_wrappers/fluent/v2020R1.jou
+++ b/coupling_components/solver_wrappers/fluent/v2020R1.jou
@@ -87,8 +87,12 @@ define user-defined execute-on-demand "get_thread_ids::v2020R1"
 )
 ;
 ;   STORE COORDINATES AND IDS
-define user-defined execute-on-demand "store_coordinates_id::v2020R1"
-(send_message "nodes_and_faces_stored")
+(if (= timestep_start 0)
+    (begin
+        (ti-menu-load-string "define user-defined execute-on-demand \"store_coordinates_id::v2020R1\"")
+        (send_message "nodes_and_faces_stored")
+    )
+)
 ;
 ;   SET DELTA_T
 (if unsteady

--- a/coupling_components/solver_wrappers/fluent/v2020R1.jou
+++ b/coupling_components/solver_wrappers/fluent/v2020R1.jou
@@ -47,7 +47,7 @@ file start-transcript "transcript.txt"
 ;   READ CASE/DATA, COMPILE AND LOAD UDF
 (if (= timestep_start 0)
     (begin
-        (ti-menu-load-string "file read-case |CASE|")
+        (ti-menu-load-string "file read-case-data |CASE|")
         (ti-menu-load-string "solve set expert y n y")
         (rp-var-define 'udf/timestep 0 'int #f)
         (rp-var-define 'udf/iteration 0 'int #f)
@@ -87,22 +87,8 @@ define user-defined execute-on-demand "get_thread_ids::v2020R1"
 )
 ;
 ;   STORE COORDINATES AND IDS
-;(if (= timestep_start 0)
-;    (begin
-;        (ti-menu-load-string "define user-defined execute-on-demand \"store_coordinates_id::v2020R1\"")
-;        (send_message "nodes_and_faces_stored")
-;    )
-;)
 define user-defined execute-on-demand "store_coordinates_id::v2020R1"
 (send_message "nodes_and_faces_stored")
-;
-;   INITIALIZE SOLUTION
-(if (= timestep_start 0)
-    (if |HYBRID_INITIALIZATION|
-        (ti-menu-load-string "solve initialize hyb-initialization")
-        (ti-menu-load-string "solve initialize initialize-flow")
-    )
-)
 ;
 ;   SET DELTA_T
 (if unsteady

--- a/examples/test_single_solver/parameters.json
+++ b/examples/test_single_solver/parameters.json
@@ -76,7 +76,6 @@
           "cores": 6,
           "fluent_gui": false,
           "max_nodes_per_face": 4,
-          "hybrid_initialization": false,
           "flow_iterations": 200,
           "save_iterations": 1
         }

--- a/examples/tube_fluent2d_abaqus2d/parameters.json
+++ b/examples/tube_fluent2d_abaqus2d/parameters.json
@@ -71,7 +71,6 @@
           "cores": 4,
           "fluent_gui": false,
           "max_nodes_per_face": 2,
-          "hybrid_initialization": false,
           "flow_iterations": 200,
           "save_iterations": 1
         }

--- a/examples/tube_fluent2d_abaqus2d/setup_fluent/case.jou
+++ b/examples/tube_fluent2d_abaqus2d/setup_fluent/case.jou
@@ -48,6 +48,7 @@ solve set flow-warnings n
 solve initialize set-defaults pressure 0
 solve initialize set-defaults x-velocity 0
 solve initialize set-defaults y-velocity 0
+solve initialize initialize-flow
 
-file write-case case_tube2d.cas
+file write-case-data case_tube2d.cas
 exit

--- a/examples/tube_fluent2d_abaqus2d_steady/parameters.json
+++ b/examples/tube_fluent2d_abaqus2d_steady/parameters.json
@@ -71,7 +71,6 @@
           "cores": 4,
           "fluent_gui": false,
           "max_nodes_per_face": 2,
-          "hybrid_initialization": false,
           "flow_iterations": 200,
           "save_iterations": 1
         }

--- a/examples/tube_fluent2d_abaqus2d_steady/setup_fluent/case.jou
+++ b/examples/tube_fluent2d_abaqus2d_steady/setup_fluent/case.jou
@@ -46,6 +46,7 @@ solve set flow-warnings n
 solve initialize set-defaults pressure 0
 solve initialize set-defaults x-velocity 0
 solve initialize set-defaults y-velocity 0
+solve initialize initialize-flow
 
-file write-case case_tube2d.cas
+file write-case-data case_tube2d.cas
 exit

--- a/examples/tube_fluent2d_tube_structure/parameters.json
+++ b/examples/tube_fluent2d_tube_structure/parameters.json
@@ -71,7 +71,6 @@
           "cores": 4,
           "fluent_gui": false,
           "max_nodes_per_face": 4,
-          "hybrid_initialization": false,
           "flow_iterations": 200,
           "save_iterations": 1
         }

--- a/examples/tube_fluent2d_tube_structure/setup_fluent/case.jou
+++ b/examples/tube_fluent2d_tube_structure/setup_fluent/case.jou
@@ -48,6 +48,7 @@ solve set flow-warnings n
 solve initialize set-defaults pressure 0
 solve initialize set-defaults x-velocity 0
 solve initialize set-defaults y-velocity 0
+solve initialize initialize-flow
 
-file write-case case_tube2d.cas
+file write-case-data case_tube2d.cas
 exit

--- a/examples/tube_fluent3d_abaqus2d/parameters.json
+++ b/examples/tube_fluent3d_abaqus2d/parameters.json
@@ -71,7 +71,6 @@
           "cores": 6,
           "fluent_gui": false,
           "max_nodes_per_face": 4,
-          "hybrid_initialization": false,
           "flow_iterations": 200,
           "save_iterations": 1
         }

--- a/examples/tube_fluent3d_abaqus2d/setup_fluent/case.jou
+++ b/examples/tube_fluent3d_abaqus2d/setup_fluent/case.jou
@@ -53,6 +53,7 @@ solve initialize set-defaults pressure 0
 solve initialize set-defaults x-velocity 0
 solve initialize set-defaults y-velocity 0
 solve initialize set-defaults z-velocity 0
+solve initialize initialize-flow
 
-file write-case case_tube3d.cas
+file write-case-data case_tube3d.cas
 exit

--- a/examples/tube_fluent3d_abaqus3d/parameters.json
+++ b/examples/tube_fluent3d_abaqus3d/parameters.json
@@ -71,7 +71,6 @@
           "cores": 6,
           "fluent_gui": false,
           "max_nodes_per_face": 4,
-          "hybrid_initialization": false,
           "flow_iterations": 200,
           "save_iterations": 1
         }

--- a/examples/tube_fluent3d_abaqus3d/setup_fluent/case.jou
+++ b/examples/tube_fluent3d_abaqus3d/setup_fluent/case.jou
@@ -53,6 +53,7 @@ solve initialize set-defaults pressure 0
 solve initialize set-defaults x-velocity 0
 solve initialize set-defaults y-velocity 0
 solve initialize set-defaults z-velocity 0
+solve initialize initialize-flow
 
-file write-case case_tube3d.cas
+file write-case-data case_tube3d.cas
 exit

--- a/examples/tube_fluent3d_kratos_structure3d/parameters.json
+++ b/examples/tube_fluent3d_kratos_structure3d/parameters.json
@@ -71,7 +71,6 @@
           "cores": 6,
           "fluent_gui": false,
           "max_nodes_per_face": 4,
-          "hybrid_initialization": false,
           "flow_iterations": 200,
           "save_iterations": 1
         }

--- a/examples/tube_fluent3d_kratos_structure3d/setup_fluent/case.jou
+++ b/examples/tube_fluent3d_kratos_structure3d/setup_fluent/case.jou
@@ -53,6 +53,7 @@ solve initialize set-defaults pressure 0
 solve initialize set-defaults x-velocity 0
 solve initialize set-defaults y-velocity 0
 solve initialize set-defaults z-velocity 0
+solve initialize initialize-flow
 
-file write-case case_tube3d.cas
+file write-case-data case_tube3d.cas
 exit

--- a/tests/solver_wrappers/fluent/test_v2019R1/tube2d/parameters.json
+++ b/tests/solver_wrappers/fluent/test_v2019R1/tube2d/parameters.json
@@ -30,7 +30,6 @@
     "cores": 4,
     "fluent_gui": false,
     "max_nodes_per_face": 4,
-    "hybrid_initialization": false,
     "flow_iterations": 200,
     "save_iterations": 1
   }

--- a/tests/solver_wrappers/fluent/test_v2019R1/tube2d/setup_fluent/case.jou
+++ b/tests/solver_wrappers/fluent/test_v2019R1/tube2d/setup_fluent/case.jou
@@ -48,6 +48,7 @@ solve set flow-warnings n
 solve initialize set-defaults pressure 0
 solve initialize set-defaults x-velocity 0
 solve initialize set-defaults y-velocity 0
+solve initialize initialize-flow
 
-file write-case case_tube2d.cas
+file write-case-data case_tube2d.cas
 exit

--- a/tests/solver_wrappers/fluent/test_v2019R1/tube3d/parameters.json
+++ b/tests/solver_wrappers/fluent/test_v2019R1/tube3d/parameters.json
@@ -30,7 +30,6 @@
     "cores": 4,
     "fluent_gui": false,
     "max_nodes_per_face": 4,
-    "hybrid_initialization": false,
     "flow_iterations": 200,
     "save_iterations": 1
   }

--- a/tests/solver_wrappers/fluent/test_v2019R1/tube3d/setup_fluent/case.jou
+++ b/tests/solver_wrappers/fluent/test_v2019R1/tube3d/setup_fluent/case.jou
@@ -52,6 +52,7 @@ solve initialize set-defaults pressure 0
 solve initialize set-defaults x-velocity 0
 solve initialize set-defaults y-velocity 0
 solve initialize set-defaults z-velocity 0
+solve initialize initialize-flow
 
-file write-case case_tube3d.cas
+file write-case-data case_tube3d.cas
 exit

--- a/tests/solver_wrappers/fluent/test_v2019R2/tube2d/parameters.json
+++ b/tests/solver_wrappers/fluent/test_v2019R2/tube2d/parameters.json
@@ -30,7 +30,6 @@
     "cores": 4,
     "fluent_gui": false,
     "max_nodes_per_face": 4,
-    "hybrid_initialization": false,
     "flow_iterations": 200,
     "save_iterations": 1
   }

--- a/tests/solver_wrappers/fluent/test_v2019R2/tube3d/parameters.json
+++ b/tests/solver_wrappers/fluent/test_v2019R2/tube3d/parameters.json
@@ -30,7 +30,6 @@
     "cores": 4,
     "fluent_gui": false,
     "max_nodes_per_face": 4,
-    "hybrid_initialization": false,
     "flow_iterations": 200,
     "save_iterations": 1
   }

--- a/tests/solver_wrappers/fluent/test_v2019R3/tube2d/parameters.json
+++ b/tests/solver_wrappers/fluent/test_v2019R3/tube2d/parameters.json
@@ -30,7 +30,6 @@
     "cores": 4,
     "fluent_gui": false,
     "max_nodes_per_face": 4,
-    "hybrid_initialization": false,
     "flow_iterations": 200,
     "save_iterations": 1
   }

--- a/tests/solver_wrappers/fluent/test_v2019R3/tube3d/parameters.json
+++ b/tests/solver_wrappers/fluent/test_v2019R3/tube3d/parameters.json
@@ -30,7 +30,6 @@
     "cores": 4,
     "fluent_gui": false,
     "max_nodes_per_face": 4,
-    "hybrid_initialization": false,
     "flow_iterations": 200,
     "save_iterations": 1
   }

--- a/tests/solver_wrappers/fluent/test_v2020R1/tube2d/parameters.json
+++ b/tests/solver_wrappers/fluent/test_v2020R1/tube2d/parameters.json
@@ -30,7 +30,6 @@
     "cores": 4,
     "fluent_gui": false,
     "max_nodes_per_face": 4,
-    "hybrid_initialization": false,
     "flow_iterations": 200,
     "save_iterations": 1
   }

--- a/tests/solver_wrappers/fluent/test_v2020R1/tube3d/parameters.json
+++ b/tests/solver_wrappers/fluent/test_v2020R1/tube3d/parameters.json
@@ -30,7 +30,6 @@
     "cores": 4,
     "fluent_gui": false,
     "max_nodes_per_face": 4,
-    "hybrid_initialization": false,
     "flow_iterations": 200,
     "save_iterations": 1
   }


### PR DESCRIPTION
**Description:** I adjusted the code such that the Fluent wrapper does not initialize the case anymore. This is now the responsibility of the user, who also has to provide a data file. I also added a check on the presence of the data-file, such that a clear error is generated when it's not there. This change allows a case to start from a CFD-solution as initial condition.

**Users' experience:** The user has now to provide a data-file with data present in the flow-field (initialization or CFD-only calculation). The key hybrid_initialization can now be omitted from the JSON-files, it is used nowhere anymore.

**Tests:** I tested whether the tube_fluent2d_tube_structure resulted in the same convergence history as previously, which was the case. I also ran the unittests for all versions.

**Related issues:** Closes #89. 

**Checklist**
- [x] Style guidelines
- [x] Self-review of code performed
- [x] Code has been commented (particularly in hard-to-understand areas)
- [ ] Documentation was updated correspondingly: **I will do this in the docs-maintenance branch when this pull request is approved, unless the docs-maintenance branch gets merged sooner.**
- [x] New and existing unit tests pass locally with changes
