### PR TITLE
Remove interpolator parameter

### DIFF
--- a/coupling_components/mappers/combined.py
+++ b/coupling_components/mappers/combined.py
@@ -3,6 +3,7 @@ from coconut.coupling_components.component import Component
 from coconut.tools import create_instance
 from coconut import data_structure
 from coconut.data_structure import variables_dimensions
+from coconut.coupling_components.mappers.interpolator import MapperInterpolator
 
 
 def create(parameters):
@@ -35,7 +36,7 @@ class MapperCombined(Component):
         # check that exactly one mapper is an interpolator
         counter = 0
         for i, mapper in enumerate(self.mappers):
-            if mapper.interpolator:
+            if isinstance(mapper, MapperInterpolator):
                 self.index = i
                 counter += 1
         if counter != 1:

--- a/coupling_components/mappers/interpolator.py
+++ b/coupling_components/mappers/interpolator.py
@@ -35,10 +35,9 @@ class MapperInterpolator(Component):
             raise TypeError('Directions must be a list')
         for direction in self.settings['directions']:
             if direction.lower() not in ['x', 'y', 'z']:
-                raise ValueError(f'"{direction}" is not a valid direction.')
+                raise ValueError(f'"{direction}" is not a valid direction')
             if direction.lower() != direction:
-                # TODO: I would later remove this and only accept lowercase directions
-                tools.print_info('Warning: Interpolator directions must be lowercase', layout='warning')
+                raise ValueError(f'"{direction}" must be lowercase')
             self.directions.append(direction.lower() + '0')
             if len(self.directions) > 3:
                 raise ValueError(f'Too many directions given')

--- a/coupling_components/mappers/interpolator.py
+++ b/coupling_components/mappers/interpolator.py
@@ -11,13 +11,13 @@ def create(parameters):
 
 # TODO: warnings now crash the code... this should not happen
 
+
 class MapperInterpolator(Component):
     def __init__(self, parameters):
         super().__init__()
 
         # store settings
         self.settings = parameters['settings']
-        self.interpolator = True
         self.balanced_tree = self.settings.get('balanced_tree', False)
         self.n_nearest = 0  # must be set in sub-class!
 

--- a/coupling_components/mappers/transformer.py
+++ b/coupling_components/mappers/transformer.py
@@ -11,7 +11,6 @@ class MapperTransformer(Component):
         super().__init__()
 
         self.settings = parameters['settings']
-        self.interpolator = False
 
     def __call__(self, args_from, args_to):
         # check variables

--- a/tests/mappers/test_interpolator.py
+++ b/tests/mappers/test_interpolator.py
@@ -29,9 +29,8 @@ class TestMapperInterpolator(unittest.TestCase):
         mapper = create_instance(self.parameters)
         self.assertListEqual(mapper.directions, ['z0', 'y0', 'x0'])
 
-        # TODO: add this again, after all capitals have been removed
-        # self.parameters['settings'].SetArray('directions', ['Z'])
-        # self.assertRaises(ValueError, create_instance, self.parameters)
+        self.parameters['settings']['directions'] = ['Z']
+        self.assertRaises(ValueError, create_instance, self.parameters)
 
         self.parameters['settings']['directions'] = ['z0']
         self.assertRaises(ValueError, create_instance, self.parameters)


### PR DESCRIPTION
**Description** Interpolator boolean was removed in interpolator and transformer base classes.
Lower case interpolator directions are now mandatory.

**User experience** Before it was a strong recommendation to use lowercase interpolator directions; now it is mandatory.

**Affected code** No code is affected outside mappers.

**Tests** All tests work. Example tube_fluent3d_abaqus3d has been ran before and after modification for 3 time steps, without difference.

Closes #92.

**Checklist**
- [x] Style guidelines
    1. CoCoNuT follows [the PEP8 style guide](https://www.python.org/dev/peps/pep-0008/).
    2. Comments should be lowercase.
    3. Errors should start with capitals, preferably without punctuation unless it's multiple sentences.
    4. Strings should use single quotes whenever possible.	
- [x] Self-review of code performed
- [x] Code has been commented (particularly in hard-to-understand areas)
- [x] Documentation was updated correspondingly: no documentation had to be altered.
- [x] New and existing unit tests pass locally with changes
