### PR TITLE
Delete superclass to avoid the tests to be executed

### DIFF
--- a/tests/solver_wrappers/fluent/test_v2019R1.py
+++ b/tests/solver_wrappers/fluent/test_v2019R1.py
@@ -10,9 +10,6 @@ import multiprocessing
 
 # TODO: issue: id is a Python build-in function... use ids instead?
 
-# TODO: The unittests for the other Fluent versions currently inherit from these classes. Because those modules import
-#   these super classes, they are also run and crash, which is kinda ugly.
-
 
 class TestSolverWrapperFluent2019R1Tube2D(unittest.TestCase):
     version = '2019R1'

--- a/tests/solver_wrappers/fluent/test_v2019R2.py
+++ b/tests/solver_wrappers/fluent/test_v2019R2.py
@@ -14,5 +14,7 @@ class TestSolverWrapperFluent2019R2Tube3D(TestSolverWrapperFluent2019R1Tube3D):
     setup_case = True
 
 
+del TestSolverWrapperFluent2019R1Tube2D, TestSolverWrapperFluent2019R1Tube3D  # to avoid executing 2019 test too
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/solver_wrappers/fluent/test_v2019R3.py
+++ b/tests/solver_wrappers/fluent/test_v2019R3.py
@@ -14,5 +14,7 @@ class TestSolverWrapperFluent2019R3Tube3D(TestSolverWrapperFluent2019R1Tube3D):
     setup_case = True
 
 
+del TestSolverWrapperFluent2019R1Tube2D, TestSolverWrapperFluent2019R1Tube3D  # to avoid executing 2019 test too
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/solver_wrappers/fluent/test_v2020R1.py
+++ b/tests/solver_wrappers/fluent/test_v2020R1.py
@@ -14,5 +14,7 @@ class TestSolverWrapperFluent2020R1Tube3D(TestSolverWrapperFluent2019R1Tube3D):
     setup_case = True
 
 
+del TestSolverWrapperFluent2019R1Tube2D, TestSolverWrapperFluent2019R1Tube3D  # to avoid executing 2019 test too
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description** 
If the tests for Fluent versions other than 2019R1 were run directly from the file (e.g. `python -m unittest -bv solver_wrappers/fluent/test_2020R1.py`) it also *tried* to run the 2019R1 tests which then failed. This is because those test inherit from the test classes in `test_v2019R1.py`, for which those classes have to be imported. I solved this by deleting these classes again after the subclasses have been created, such that they cannot be discovered by the unittest module.

For your information:
An alternative approach I also tried was suggested in [this post on StackOverflow](https://stackoverflow.com/questions/1323455/python-unit-test-with-base-and-sub-class/25695512#25695512). For that, the module containing the classes should be imported instead of the classes directly, because then unittest does not discover the class inside that module. I tried it in [this branch](https://github.com/pyfsi/coconut/compare/avoid-duplicate-different-import), but it only works if the content of *`coconut/tests/solver_wrappers/__init__.py`* is removed, otherwise an error is raised (`AttributeError: module 'coconut.tests' has no attribute 'solver_wrappers'`). I thus think that is not an option as we need to keep the content in that `__init__.py` file, or does it indicate something else needs to be fixed?
 
@toondm : I see there was another TODO about having `id` as a variable. It is not clear to me whether this is still to be done.

**Users' experience affected?**
No.

**Other parts of the code affected?**
No.

**Tests**
Unittest of all Fluent versions work when ran from their file as well as when ran as part of a TestSuite.

**Related issues**
Fixes #107 

**Checklist**
- [x] Style guidelines
- [x] Self-review of code performed
- [x] Code has been commented (particularly in hard-to-understand areas)
- [x] Documentation was updated correspondingly
- [x] New and existing unit tests pass locally with changes
