### PR TITLE
Abaqus reduce pre

### DIFF
--- a/coupling_components/solver_wrappers/abaqus/abaqus_v6.env
+++ b/coupling_components/solver_wrappers/abaqus/abaqus_v6.env
@@ -14,7 +14,3 @@ link_sl.remove('-i-dynamic')
 link_exe=link_exe+['-Xlinker -L/usr/lib64/']
 del os
 del mp_mode_string
-if applicationName in ('cae','viewer'):
-	abaquslm_license_file="@bump.ugent.be"
-else:
-	abaquslm_license_file="@ir03lic1.ugent.be"

--- a/coupling_components/solver_wrappers/abaqus/v614.py
+++ b/coupling_components/solver_wrappers/abaqus/v614.py
@@ -31,6 +31,9 @@ class SolverWrapperAbaqus614(Component):
         self.dir_csm = join(os.getcwd(), self.settings['working_directory'])  # *** alternative for getcwd?
         self.env = tools.get_solver_env(__name__, self.dir_csm)
         self.check_software()
+        self.dir_vault = Path(self.dir_csm) / 'vault'
+        self.dir_vault.mkdir(exist_ok=True)
+        self.vault_suffixes = ['023', 'com', 'dat', 'mdl', 'msg', 'odb', 'prt', 'res', 'sim', 'stt']
         path_src = os.path.realpath(os.path.dirname(__file__))
         self.logfile = 'abaqus.log'
 
@@ -359,9 +362,33 @@ class SolverWrapperAbaqus614(Component):
                     f'cpus={self.cores} output_precision=full interactive >> {self.logfile} 2>&1'
                 subprocess.run(cmd, shell=True, cwd=self.dir_csm, executable='/bin/bash', env=self.env)
             else:
-                cmd = f'abaqus job=CSM_Time{self.timestep} oldjob=CSM_Time{self.timestep - 1} input=CSM_Restart ' \
-                    f'cpus={self.cores} output_precision=full interactive >> {self.logfile} 2>&1'
-                subprocess.run(cmd, shell=True, cwd=self.dir_csm, executable='/bin/bash', env=self.env)
+                if self.iteration == 1:
+                    # run datacheck and store generated files safely
+                    for f in self.dir_vault.iterdir():
+                        f.unlink()  # empty vault
+                    cmd = f'abaqus datacheck job=CSM_Time{self.timestep} oldjob=CSM_Time{self.timestep - 1} ' \
+                        f'input=CSM_Restart cpus={self.cores} output_precision=full interactive ' \
+                        f'>> {self.logfile} 2>&1'
+                    subprocess.run(cmd, shell=True, cwd=self.dir_csm, executable='/bin/bash', env=self.env)
+                    for suffix in self.vault_suffixes:
+                        from_file = Path(self.dir_csm) / f'CSM_Time{self.timestep}.{suffix}'
+                        to_file = self.dir_vault / f'CSM_Time{self.timestep}.{suffix}'
+                        shutil.copy(from_file, to_file)
+                    # run continue
+                    cmd = f'abaqus continue job=CSM_Time{self.timestep} oldjob=CSM_Time{self.timestep - 1} ' \
+                        f'input=CSM_Restart cpus={self.cores} output_precision=full interactive ' \
+                        f'>> {self.logfile} 2>&1'
+                    subprocess.run(cmd, shell=True, cwd=self.dir_csm, executable='/bin/bash', env=self.env)
+                else:
+                    # run continue using previously stored simulation files
+                    for suffix in self.vault_suffixes:
+                        from_file = self.dir_vault / f'CSM_Time{self.timestep}.{suffix}'
+                        to_file = Path(self.dir_csm) / f'CSM_Time{self.timestep}.{suffix}'
+                        shutil.copy(from_file, to_file)
+                    cmd = f'abaqus continue job=CSM_Time{self.timestep} oldjob=CSM_Time{self.timestep - 1} ' \
+                        f'input=CSM_Restart cpus={self.cores} output_precision=full interactive ' \
+                        f'>> {self.logfile} 2>&1'
+                    subprocess.run(cmd, shell=True, cwd=self.dir_csm, executable='/bin/bash', env=self.env)
 
             # check log for completion and or errors
             subprocess.run(f'tail -n 10 {self.logfile} > Temp_log.coco', shell=True, cwd=self.dir_csm,

--- a/coupling_components/solver_wrappers/abaqus/v614.py
+++ b/coupling_components/solver_wrappers/abaqus/v614.py
@@ -460,6 +460,7 @@ class SolverWrapperAbaqus614(Component):
 
     def finalize(self):
         super().finalize()
+        self.dir_vault.rmdir()
 
     def get_interface_input(self):
         return self.interface_input

--- a/coupling_components/solver_wrappers/abaqus/v614.py
+++ b/coupling_components/solver_wrappers/abaqus/v614.py
@@ -364,8 +364,6 @@ class SolverWrapperAbaqus614(Component):
             else:
                 if self.iteration == 1:
                     # run datacheck and store generated files safely
-                    for f in self.dir_vault.iterdir():
-                        f.unlink()  # empty vault
                     cmd = f'abaqus datacheck job=CSM_Time{self.timestep} oldjob=CSM_Time{self.timestep - 1} ' \
                         f'input=CSM_Restart cpus={self.cores} output_precision=full interactive ' \
                         f'>> {self.logfile} 2>&1'
@@ -456,6 +454,8 @@ class SolverWrapperAbaqus614(Component):
             for suffix in to_be_removed_suffix:
                 cmd += f'rm CSM_Time{self.timestep - 1}{suffix}; '
             subprocess.run(cmd, shell=True, cwd=self.dir_csm, executable='/bin/bash', env=self.env)
+        for f in self.dir_vault.iterdir():
+            f.unlink()  # empty vault
 
     def finalize(self):
         super().finalize()

--- a/coupling_components/solver_wrappers/abaqus/v614.py
+++ b/coupling_components/solver_wrappers/abaqus/v614.py
@@ -447,15 +447,16 @@ class SolverWrapperAbaqus614(Component):
 
     def finalize_solution_step(self):
         super().finalize_solution_step()
-        if self.save_interval == 0 or (self.timestep - 1) % self.save_interval != 0:
-            to_be_removed_suffix = ['.com', '.dat', '.mdl', '.msg', '.odb', '.prt', '.res', '.sim', '.sta', '.stt',
-                                    'Surface*Cpu0Input.dat', 'Surface*Output.dat']
-            cmd = ''
-            for suffix in to_be_removed_suffix:
-                cmd += f'rm CSM_Time{self.timestep - 1}{suffix}; '
-            subprocess.run(cmd, shell=True, cwd=self.dir_csm, executable='/bin/bash', env=self.env)
-        for f in self.dir_vault.iterdir():
-            f.unlink()  # empty vault
+        if self.timestep > 0:
+            if self.save_interval == 0 or (self.timestep - 1) % self.save_interval != 0:
+                to_be_removed_suffix = ['.com', '.dat', '.mdl', '.msg', '.odb', '.prt', '.res', '.sim', '.sta', '.stt',
+                                        'Surface*Cpu0Input.dat', 'Surface*Output.dat']
+                cmd = ''
+                for suffix in to_be_removed_suffix:
+                    cmd += f'rm CSM_Time{self.timestep - 1}{suffix}; '
+                subprocess.run(cmd, shell=True, cwd=self.dir_csm, executable='/bin/bash', env=self.env)
+            for f in self.dir_vault.iterdir():
+                f.unlink()  # empty vault
 
     def finalize(self):
         super().finalize()

--- a/solver_modules.py
+++ b/solver_modules.py
@@ -5,7 +5,7 @@ uses the environment variables in all the spawned processes, used for executing 
 in the various stages of the simulation.
 """
 
-machine_name = 'ugent_cluster_SL6.3'
+machine_name = 'ugent_cluster_CO7'
 
 solver_load_cmd_dict = {
     'ugent_cluster_SL6.3': {
@@ -13,8 +13,7 @@ solver_load_cmd_dict = {
         'fluent.v2019R2': 'ml ANSYS_CFD/2019R2',
         'fluent.v2019R3': 'ml ANSYS_CFD/2019R3',
         'fluent.v2020R1': 'ml ANSYS_CFD/2020R1',
-        'abaqus.v614': 'ml intel/2018a && ml ABAQUS/6.14',
-        'abaqus.v614_branch': 'ml intel/2018a && ml ABAQUS/6.14',
+        'abaqus.v614': 'ml intel/2018a && ml ABAQUS/6.14 && export LM_LICENSE_FILE=@ir03lic1.ugent.be:@bump.ugent.be',
         'kratos.structural_mechanics_application.v60': 'ml Kratos/6.0-foss-2018a-Python-3.6.4',
         'openfoam.v41': 'ml OpenFOAM/4.1 && source $FOAM_BASH'
     },

--- a/solver_modules.py
+++ b/solver_modules.py
@@ -14,13 +14,14 @@ solver_load_cmd_dict = {
         'fluent.v2019R3': 'ml ANSYS_CFD/2019R3',
         'fluent.v2020R1': 'ml ANSYS_CFD/2020R1',
         'abaqus.v614': 'ml intel/2018a && ml ABAQUS/6.14',
+        'abaqus.v614_branch': 'ml intel/2018a && ml ABAQUS/6.14',
         'kratos.structural_mechanics_application.v60': 'ml Kratos/6.0-foss-2018a-Python-3.6.4',
         'openfoam.v41': 'ml OpenFOAM/4.1 && source $FOAM_BASH'
     },
     'ugent_cluster_CO7': {
         'fluent.v2019R3': 'ml ANSYS_CFD/2019R3',
         'fluent.v2020R1': 'ml ANSYS_CFD/2020R1',
-        'abaqus.v614': 'ml intel/2018a && ml ABAQUS/6.14',
+        'abaqus.v614': 'ml intel/2018a && ml ABAQUS/6.14 && export LM_LICENSE_FILE=@ir03lic1.ugent.be:@bump.ugent.be',
         'kratos.structural_mechanics_application.v60': 'ml Kratos/6.0-foss-2018a-Python-3.6.4',
         'openfoam.v41': 'ml OpenFOAM/4.1-foss-2016b && source $FOAM_BASH'
     },
@@ -28,7 +29,8 @@ solver_load_cmd_dict = {
         'fluent.v2019R1': 'ml ANSYS_CFD/2019R1',
         'fluent.v2019R2': 'ml ANSYS_CFD/2019R2',
         'fluent.v2019R3': 'ml FLUENT/2019R3',
-        'abaqus.v614': 'ml intel/2018a && ml ABAQUS/6.14.1-linux-x86_64 && unset SLURM_GTIDS',
+        'abaqus.v614': 'ml intel/2018a && ml ABAQUS/6.14.1-linux-x86_64 && unset SLURM_GTIDS && export LM_LICENSE_FILE='
+                       '@ir03lic1.ugent.be:@bump.ugent.be',
         'kratos.structural_mechanics_application.v60': 'ml Kratos/6.0-foss-2018a-Python-3.6.4',
     }
 }

--- a/tests/solver_wrappers/abaqus/test_v614/tube2d/setup_abaqus/case_tube2d.inp
+++ b/tests/solver_wrappers/abaqus/test_v614/tube2d/setup_abaqus/case_tube2d.inp
@@ -1204,7 +1204,7 @@ _MOVINGSURFACE0_S1, S1
 ** 
 *Step, name=Step-1, nlgeom=YES, inc=1
 *Dynamic,application=QUASI-STATIC,direct,nohaf,initial=NO
-0.0001,0.0001,
+0.001,0.001,
 ** 
 ** BOUNDARY CONDITIONS
 ** 


### PR DESCRIPTION
**Description** A small speed-up has been achieved by eliminating the execution of the _pre_ executable in every coupling iteration. Instead it is only run in the first coupling iteration of the time step using _abaqus datacheck_, after which the created files are copied to a separate folder "_`vault`_" and copied back for each subsequent coupling iteration within the time step, which is run using _abaqus continue_. This procedure is not followed in the first time step, as for some reason then the convergence history changes for transient cases. A speed test has been run on the _`tube_tube_flow_abaqus2d`_ example, resulting in a reduction of about 6% spent in `SolverWrapperAbaqus614`. 10 tests were performed to have statistically reliable results. For a second test, the Abaqus model was refined to 100000 elements (of which 10000 are located on the interface). There a reduction of about 2.8% was realized. Below the box-and-whisker plots are shown for both tests, the data can be found [here](https://github.com/pyfsi/coconut/files/6615270/timings.xlsx). It is concluded that the changes did not slow down the wrapper and have the potential to speed up cases in which the _pre_ executable consumes a lot of time. For example in wind turbine FSI simulations we did in the past, _pre_ took 13.5-16 minutes per coupling iteration, while _standard_ only needed about _5.5_ minutes. 

<img src="https://user-images.githubusercontent.com/52496779/121161543-648e0c80-c84d-11eb-9c5f-9fe3999245d7.png" alt="Test 1" width="400"/><img src="https://user-images.githubusercontent.com/52496779/121161586-6c4db100-c84d-11eb-8786-64f3e39a0cdd.png" alt="Test 2" width="400"/>

Another change is that the license files are now redundantly set in the *`solver_modules.py`* file. This makes the *`abaqus_v6.env`* file more portable, as it doesn't contain system specific information anymore. Supplying redundant license files reduces the chance of ending up in the license queue.

**Users' experience affected?** No.

**Other parts of the code affected?** No.

**Tests** The tests pass. The convergence history for the following examples was compared: _`tube_tube_flow_abaqus2d`_, _`tube_fluent2d_abaqus2d_steady`_ and _`tube_fluent3d_abaqus3d`_ and was found to be the same.

**Related issues** Closes #43 

**Checklist**
- [x] Style guidelines
- [x] Self-review of code performed
- [x] Code has been commented (particularly in hard-to-understand areas)
- [x] Documentation was updated correspondingly
- [x] New and existing unit tests pass locally with changes
