### PR TITLE
Change directory name in /tmp

### DIFF
--- a/coupling_components/solver_wrappers/abaqus/abaqus_v6.env
+++ b/coupling_components/solver_wrappers/abaqus/abaqus_v6.env
@@ -4,7 +4,7 @@ mp_mode=|MP_MODE|
 mp_host_list=|HOSTNAME|
 mp_mode_string='|MP_MODE|'
 standard_parallel=ALL
-scratch='/tmp/CoCoNuT|PID|/CSM/'
+scratch='/tmp/coconut_|USER|_|PID|_abaqus/'
 usub_lib_dir=os.path.join(os.getcwd(), 'libusr/')
 if mp_mode_string.lower() == 'mpi':
 	compile_fortran=compile_fortran+['-fpp', ('-I'+os.path.dirname(mp_mpirun_path[mp_mpi_implementation])+'/../include/64'), '-DMPI ']

--- a/coupling_components/solver_wrappers/abaqus/v614.py
+++ b/coupling_components/solver_wrappers/abaqus/v614.py
@@ -13,6 +13,7 @@ import re
 import textwrap
 from pathlib import Path
 import warnings
+from getpass import getuser
 
 
 def create(parameters):
@@ -72,6 +73,7 @@ class SolverWrapperAbaqus614(Component):
                         else (line, '')['|HOSTNAME|' in line]  # replace |HOSTNAME| if MPI else remove line
                     line = line.replace('|MP_MODE|', self.mp_mode)
                     line = line.replace('|PID|', str(os.getpid()))
+                    line = line.replace('|USER|', getuser())
                     if '|' in line:
                         raise ValueError(f'The following line in abaqus_v6.env still contains a \'|\' after '
                                          f'substitution: \n \t{line} \n Probably a parameter was not substituted')

--- a/coupling_components/solver_wrappers/fluent/fluent.py
+++ b/coupling_components/solver_wrappers/fluent/fluent.py
@@ -10,6 +10,8 @@ import time
 import numpy as np
 import sys
 import hashlib
+from getpass import getuser
+import shutil
 
 
 # TODO: issue: id and hash shadow built-in names
@@ -35,6 +37,7 @@ class SolverWrapperFluent(Component):
         self.env = None  # environment in which correct version of Fluent software is available, set in sub-class
         self.remove_all_messages()
         self.dir_src = os.path.realpath(os.path.dirname(__file__))
+        self.tmp_directory_name = f'coconut_{getuser()}_{os.getpid()}_fluent'  # dir in /tmp for host-node communication
         self.cores = self.settings['cores']
         if self.cores < 1 or self.cores > multiprocessing.cpu_count():
             self.cores = multiprocessing.cpu_count()  # TODO: add this behavior to documentation
@@ -92,13 +95,15 @@ class SolverWrapperFluent(Component):
                     outfile.write(line)
 
         # prepare Fluent UDF
-        if self.timestep_start == 0:
-            udf = f'v{self.version}.c'
-            with open(join(self.dir_src, udf)) as infile:
-                with open(join(self.dir_cfd, udf), 'w') as outfile:
-                    for line in infile:
-                        line = line.replace('|MAX_NODES_PER_FACE|', str(self.mnpf))
-                        outfile.write(line)
+        udf = f'v{self.version}.c'
+        shutil.rmtree(join('/tmp', self.tmp_directory_name), ignore_errors=True)
+        os.mkdir(join('/tmp', self.tmp_directory_name))
+        with open(join(self.dir_src, udf)) as infile:
+            with open(join(self.dir_cfd, udf), 'w') as outfile:
+                for line in infile:
+                    line = line.replace('|MAX_NODES_PER_FACE|', str(self.mnpf))
+                    line = line.replace('|TMP_DIRECTORY_NAME|', self.tmp_directory_name)
+                    outfile.write(line)
 
         # start Fluent with journal
         log = join(self.dir_cfd, 'fluent.log')
@@ -321,6 +326,7 @@ class SolverWrapperFluent(Component):
 
     def finalize(self):
         super().finalize()
+        shutil.rmtree(join('/tmp', self.tmp_directory_name), ignore_errors=True)
         self.send_message('stop')
         self.wait_message('stop_ready')
         self.fluent_process.wait()

--- a/coupling_components/solver_wrappers/fluent/v2019R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2019R1.c
@@ -498,9 +498,9 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     sprintf(file_name, "nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
 #else
-    sprintf(file_name, "/tmp/nodes_update_timestep%i_thread%i.dat",
+    sprintf(file_name, "/tmp/|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
-    host_to_node_sync_file("/tmp");
+    host_to_node_sync_file("/tmp/|TMP_DIRECTORY_NAME|");
 #endif /* !RP_NODE */
 
 #if RP_HOST

--- a/coupling_components/solver_wrappers/fluent/v2019R2.c
+++ b/coupling_components/solver_wrappers/fluent/v2019R2.c
@@ -498,9 +498,9 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     sprintf(file_name, "nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
 #else
-    sprintf(file_name, "/tmp/nodes_update_timestep%i_thread%i.dat",
+    sprintf(file_name, "/tmp/|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
-    host_to_node_sync_file("/tmp");
+    host_to_node_sync_file("/tmp/|TMP_DIRECTORY_NAME|");
 #endif /* !RP_NODE */
 
 #if RP_HOST

--- a/coupling_components/solver_wrappers/fluent/v2019R3.c
+++ b/coupling_components/solver_wrappers/fluent/v2019R3.c
@@ -498,9 +498,9 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     sprintf(file_name, "nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
 #else
-    sprintf(file_name, "/tmp/nodes_update_timestep%i_thread%i.dat",
+    sprintf(file_name, "/tmp/|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
-    host_to_node_sync_file("/tmp");
+    host_to_node_sync_file("/tmp/|TMP_DIRECTORY_NAME|");
 #endif /* !RP_NODE */
 
 #if RP_HOST

--- a/coupling_components/solver_wrappers/fluent/v2020R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2020R1.c
@@ -498,9 +498,9 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     sprintf(file_name, "nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
 #else
-    sprintf(file_name, "/tmp/nodes_update_timestep%i_thread%i.dat",
+    sprintf(file_name, "/tmp/|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
-    host_to_node_sync_file("/tmp");
+    host_to_node_sync_file("/tmp/|TMP_DIRECTORY_NAME|");
 #endif /* !RP_NODE */
 
 #if RP_HOST


### PR DESCRIPTION
**Description** The name of the scratch folder of Abaqus in _`/tmp/`_ is changed to _`coconut_<USER>_<PID>_abaqus`_.
The files written by Fluent in _`/tmp/`_ are now contained in a folder _`coconut_<USER>_<PID>_fluent`_. This folder is deleted at the end of the calculation for Fluent, but not for Abaqus, because the location of the scratch folder may be changed to _`/lusers/temp`_ for a very large case.
As such problems because of user overlap or running multiple cases at once are avoided.

**Users' experience affected?** None

**Other parts of the code affected?** None

**Tests** Have you tested the code? What did you verify? All relevant tests and examples work.
Additionally restart of tube_fluent2d_abaqus2d was tested explicitly by running it 4 time steps and comparing it with the restarted case after 2 time steps.

**Related issues** Closes #125 

**Checklist**
- [x] Style guidelines
    1. CoCoNuT follows [the PEP8 style guide](https://www.python.org/dev/peps/pep-0008/).
    2. Comments should be lowercase.
    3. Errors should start with capitals, preferably without punctuation unless it's multiple sentences.
    4. Strings should use single quotes whenever possible.	
- [x] Self-review of code performed
- [x] Code has been commented (particularly in hard-to-understand areas)
- [x] Documentation was updated correspondingly
- [x] New and existing unit tests pass locally with changes
