### PR TITLE
Abaqus updates

### DIFF
--- a/coupling_components/solver_wrappers/abaqus/abaqus_v6.env
+++ b/coupling_components/solver_wrappers/abaqus/abaqus_v6.env
@@ -17,4 +17,4 @@ del mp_mode_string
 if applicationName in ('cae','viewer'):
 	abaquslm_license_file="@bump.ugent.be"
 else:
-	abaquslm_license_file="@ir03lic1.ugent.be"
+	abaquslm_license_file="@bump.ugent.be"

--- a/coupling_components/solver_wrappers/abaqus/abaqus_v6.env
+++ b/coupling_components/solver_wrappers/abaqus/abaqus_v6.env
@@ -17,4 +17,4 @@ del mp_mode_string
 if applicationName in ('cae','viewer'):
 	abaquslm_license_file="@bump.ugent.be"
 else:
-	abaquslm_license_file="@bump.ugent.be"
+	abaquslm_license_file="@ir03lic1.ugent.be"

--- a/tests/solver_wrappers/abaqus/test_v614.py
+++ b/tests/solver_wrappers/abaqus/test_v614.py
@@ -89,7 +89,7 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
 
     @staticmethod
     def get_p(x):
-        return 1500 * np.sin(2 * np.pi / 0.05 * x)
+        return 1500 * np.cos(2 * np.pi / 0.05 * x)
 
     @staticmethod
     def get_shear(x, axial_dir):

--- a/tests/solver_wrappers/abaqus/test_v614.py
+++ b/tests/solver_wrappers/abaqus/test_v614.py
@@ -6,6 +6,7 @@ import os
 from os.path import join
 import subprocess
 import json
+import shutil
 
 
 version = '614'
@@ -78,6 +79,11 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         output_single_run = solver.get_interface_output()
         cls.a1 = output_single_run.get_variable_data(cls.mp_name_out, 'displacement')
         print(f"Max disp a1: {np.max(np.abs(cls.a1), axis=0)}")
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.setup_case:
+            shutil.rmtree(cls.working_dir)
 
     def setUp(self):
         with open(self.file_name) as parameter_file:

--- a/tests/solver_wrappers/abaqus/test_v614.py
+++ b/tests/solver_wrappers/abaqus/test_v614.py
@@ -24,18 +24,22 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        dir_tmp = join(os.path.dirname(__file__), f'test_v614/tube{int(cls.dimension)}d')
+        dir_name = os.path.realpath(os.path.dirname(__file__))
+        cls.file_name = join(dir_name, f'test_v614/tube{cls.dimension}d/parameters.json')
+        cls.working_dir = join(dir_name, f'test_v614/tube{cls.dimension}d/CSM')
+        dir_tmp = join(dir_name, f'test_v614/tube{cls.dimension}d')
 
         # perform reference calculation
-        with open(join(dir_tmp, 'parameters.json')) as parameter_file:
+        with open(cls.file_name) as parameter_file:
             parameters = json.load(parameter_file)
 
+        parameters['settings']['working_directory'] = os.path.relpath(cls.working_dir)  # set working directory
         solver_name = parameters['type'].replace('solver_wrappers.', '')
         env = get_solver_env(solver_name, dir_tmp)
 
         if cls.setup_case:
-            p_setup_abaqus = subprocess.Popen('sh ' + join(dir_tmp, 'setup_abaqus.sh'), cwd=dir_tmp, shell=True, env=env)
-            p_setup_abaqus.wait()
+            p = subprocess.Popen('sh ' + join(dir_tmp, 'setup_abaqus.sh'), cwd=dir_tmp, shell=True, env=env)
+            p.wait()
 
         # create the solver
         solver = create_instance(parameters)
@@ -76,9 +80,9 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         print(f"Max disp a1: {np.max(np.abs(cls.a1), axis=0)}")
 
     def setUp(self):
-        dir_tmp = join(os.getcwd(), f'solver_wrappers/abaqus/test_v614/tube{int(self.dimension)}d')
-        with open(join(dir_tmp, 'parameters.json')) as parameter_file:
+        with open(self.file_name) as parameter_file:
             self.parameters = json.load(parameter_file)
+        self.parameters['settings']['working_directory'] = os.path.relpath(self.working_dir)  # set working directory
 
     def test_repeat_iteration(self):
         """

--- a/tests/solver_wrappers/abaqus/test_v614.py
+++ b/tests/solver_wrappers/abaqus/test_v614.py
@@ -43,7 +43,7 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         solver = create_instance(parameters)
         interface_input = solver.get_interface_input()
         model_part = interface_input.get_model_part(cls.mp_name_in)
-        coords = (model_part.x0, model_part.y0, model_part.z0)
+        coords = [model_part.x0, model_part.y0, model_part.z0]
 
         # give value to variables
         pressure = cls.get_p(coords[cls.axial_dir]).reshape(-1, 1)

--- a/tests/solver_wrappers/abaqus/test_v614.py
+++ b/tests/solver_wrappers/abaqus/test_v614.py
@@ -8,7 +8,6 @@ import subprocess
 import json
 import shutil
 
-
 version = '614'
 
 
@@ -16,7 +15,7 @@ version = '614'
 class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
     setup_case = True
     dimension = 2
-    axial_dir = 1   # y-direction is axial direction
+    axial_dir = 1  # y-direction is axial direction
     radial_dirs = [0]
     mp_name_in = 'BEAMINSIDEMOVING_load_points'
     mp_name_out = 'BEAMINSIDEMOVING_nodes'
@@ -44,12 +43,12 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         solver = create_instance(parameters)
         interface_input = solver.get_interface_input()
         model_part = interface_input.get_model_part(cls.mp_name_in)
-        coords = (model_part.x0, model_part.y0)
+        coords = (model_part.x0, model_part.y0, model_part.z0)
 
         # give value to variables
         pressure = cls.get_p(coords[cls.axial_dir]).reshape(-1, 1)
         interface_input.set_variable_data(cls.mp_name_in, 'pressure', pressure)
-        traction = np.zeros((coords[cls.axial_dir].shape[0], 3))
+        traction = np.zeros((model_part.size, 3))
         interface_input.set_variable_data(cls.mp_name_in, 'traction', traction)
 
         solver.initialize()
@@ -90,12 +89,12 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
 
     @staticmethod
     def get_p(x):
-        return 1500*np.sin(2*np.pi/0.05 * x)
+        return 1500 * np.sin(2 * np.pi / 0.05 * x)
 
     @staticmethod
     def get_shear(x, axial_dir):
         shear = np.zeros((x.shape[0], 3))
-        shear[:, axial_dir] = (x+0.025)/0.05 * 10
+        shear[:, axial_dir] = (x + 0.025) / 0.05 * 10
         return shear
 
     def test_repeat_iteration(self):
@@ -120,12 +119,12 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         solver = create_instance(self.parameters)
         interface_input = solver.get_interface_input()
         model_part = interface_input.get_model_part(self.mp_name_in)
-        coords = [model_part.x0, model_part.y0]
+        coords = [model_part.x0, model_part.y0, model_part.z0]
 
         # give value to variables
         pressure = self.get_p(coords[self.axial_dir]).reshape(-1, 1)
         interface_input.set_variable_data(self.mp_name_in, 'pressure', pressure)
-        traction = np.zeros((coords[self.axial_dir].shape[0], 3))
+        traction = np.zeros((model_part.size, 3))
         interface_input.set_variable_data(self.mp_name_in, 'traction', traction)
 
         # do step 3 and 4
@@ -149,7 +148,7 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         self.assertTrue(self.interface_x_single_run.has_same_model_parts(interface_x_restart))
         indices = sorted([self.axial_dir] + self.radial_dirs)  # columns that contain non-zero data
         a3_extra = np.delete(self.a3, indices, axis=1)  # remove columns containing data
-        np.testing.assert_array_equal(a3_extra, a3_extra * 0.0)   # if a column remains it should be all zeroes
+        np.testing.assert_array_equal(a3_extra, a3_extra * 0.0)  # if a column remains it should be all zeroes
         np.testing.assert_allclose(self.a3[:, indices], self.a1[:, indices], rtol=1e-10, atol=1e-17)  # non-zero columns
 
     def test_partitioning(self):
@@ -167,12 +166,12 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         solver = create_instance(self.parameters)
         interface_input = solver.get_interface_input()
         model_part = interface_input.get_model_part(self.mp_name_in)
-        coords = [model_part.x0, model_part.y0]
+        coords = [model_part.x0, model_part.y0, model_part.z0]
 
         # give value to variables
         pressure = self.get_p(coords[self.axial_dir]).reshape(-1, 1)
         interface_input.set_variable_data(self.mp_name_in, 'pressure', pressure)
-        traction = np.zeros((coords[self.axial_dir].shape[0], 3))
+        traction = np.zeros((model_part.size, 3))
         interface_input.set_variable_data(self.mp_name_in, 'traction', traction)
 
         # do 4 steps
@@ -191,7 +190,7 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
 
         indices = sorted([self.axial_dir] + self.radial_dirs)  # columns that contain non-zero data
         a4_extra = np.delete(self.a4, indices, axis=1)  # remove columns containing data
-        np.testing.assert_array_equal(a4_extra, a4_extra * 0.0)   # if a column remains it should be all zeroes
+        np.testing.assert_array_equal(a4_extra, a4_extra * 0.0)  # if a column remains it should be all zeroes
         np.testing.assert_allclose(self.a4[:, indices], self.a1[:, indices], rtol=1e-10, atol=1e-17)  # non-zero columns
 
     def test_shear(self):
@@ -203,7 +202,7 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
         solver = create_instance(self.parameters)
         interface_input = solver.get_interface_input()
         model_part = interface_input.get_model_part(self.mp_name_in)
-        coords = [model_part.x0, model_part.y0]
+        coords = [model_part.x0, model_part.y0, model_part.z0]
 
         # give value to variables
         pressure = self.get_p(coords[self.axial_dir]).reshape(-1, 1)
@@ -236,7 +235,7 @@ class TestSolverWrapperAbaqus614Tube2D(unittest.TestCase):
 class TestSolverWrapperAbaqus614Tube3D(TestSolverWrapperAbaqus614Tube2D):
     setup_case = True
     dimension = 3
-    axial_dir = 0   # x-direction is axial direction
+    axial_dir = 0  # x-direction is axial direction
     radial_dirs = [1, 2]
     mp_name_in = 'WALLOUTSIDE_load_points'
     mp_name_out = 'WALLOUTSIDE_nodes'

--- a/tests/solver_wrappers/abaqus/test_v614/tube2d/setup_abaqus/case_tube2d.inp
+++ b/tests/solver_wrappers/abaqus/test_v614/tube2d/setup_abaqus/case_tube2d.inp
@@ -1204,7 +1204,7 @@ _MOVINGSURFACE0_S1, S1
 ** 
 *Step, name=Step-1, nlgeom=YES, inc=1
 *Dynamic,application=QUASI-STATIC,direct,nohaf,initial=NO
-0.0001,0.0001,
+0.001,0.001,
 ** 
 ** BOUNDARY CONDITIONS
 ** 

--- a/tests/solver_wrappers/abaqus/test_v614/tube3d/setup_abaqus/case_tube3d.inp
+++ b/tests/solver_wrappers/abaqus/test_v614/tube3d/setup_abaqus/case_tube3d.inp
@@ -484,7 +484,7 @@ RIGHTFIXED, 3, 3
 ** 
 *Step, name=Step-1, nlgeom=YES, inc=1
 *Dynamic,application=QUASI-STATIC,direct,nohaf,initial=NO
-0.0001,0.0001,
+0.001,0.001,
 ** 
 ** LOADS
 ** 


### PR DESCRIPTION
**Description** 
- Abaqus unit test is able to run from its file
- *`CSM`*-directory is removed after running tests
- Pressure and traction are no longer constants in the unit tests

**Users' experience affected?** No

**Other parts of the code affected?** No

**Tests** Have you tested the code? Unit tests run both from file and how it was originally.

**Related issues** Closes #64, #72, #100

**Checklist**
- [x] Style guidelines
    1. CoCoNuT follows [the PEP8 style guide](https://www.python.org/dev/peps/pep-0008/).
    2. Comments should be lowercase.
    3. Errors should start with capitals, preferably without punctuation unless it's multiple sentences.
    4. Strings should use single quotes whenever possible.	
- [x] Self-review of code performed
- [x] Code has been commented (particularly in hard-to-understand areas)
- [x] Documentation was updated correspondingly
- [x] New and existing unit tests pass locally with changes
