### PR TITLE
Not import matplotlib if not available

### DIFF
--- a/tests/mappers/test_axisymmetric_2d_to_3d.py
+++ b/tests/mappers/test_axisymmetric_2d_to_3d.py
@@ -3,8 +3,6 @@ from coconut.tools import create_instance
 
 import numpy as np
 import unittest
-import matplotlib.pyplot as plt
-from matplotlib import cm
 
 
 class TestMapperAxisymmetric2DTo3D(unittest.TestCase):
@@ -138,6 +136,10 @@ class TestMapperAxisymmetric2DTo3D(unittest.TestCase):
 
         # extra: visualization
         if self.gui:
+            # import here to avoid error on systems without matplotlib
+            import matplotlib.pyplot as plt
+            from matplotlib import cm
+
             v_s_from, v_s_to = v_s_from.flatten(), v_s_to.flatten()
             c_from = cm.jet((v_s_from - v_s_from.min()) / (v_s_from.max() - v_s_from.min()))
             c_to = cm.jet((v_s_to - v_s_from.min()) / (v_s_from.max() - v_s_from.min()))

--- a/tests/mappers/test_axisymmetric_3d_to_2d.py
+++ b/tests/mappers/test_axisymmetric_3d_to_2d.py
@@ -4,8 +4,6 @@ from coconut.tests.mappers import test_axisymmetric_2d_to_3d
 
 import numpy as np
 import unittest
-import matplotlib.pyplot as plt
-from matplotlib import cm
 
 
 class TestMapperAxisymmetric3DTo2D(test_axisymmetric_2d_to_3d.TestMapperAxisymmetric2DTo3D):
@@ -76,6 +74,10 @@ class TestMapperAxisymmetric3DTo2D(test_axisymmetric_2d_to_3d.TestMapperAxisymme
 
         # extra: visualization
         if self.gui:
+            # import here to avoid error on systems without matplotlib
+            import matplotlib.pyplot as plt
+            from matplotlib import cm
+
             v_s_from, v_s_to = v_s_from.flatten(), v_s_to.flatten()
             c_from = cm.jet((v_s_from - v_s_from.min()) / (v_s_from.max() - v_s_from.min()))
             c_to = cm.jet((v_s_to - v_s_from.min()) / (v_s_from.max() - v_s_from.min()))

--- a/tests/mappers/test_depth_2d_to_3d.py
+++ b/tests/mappers/test_depth_2d_to_3d.py
@@ -3,8 +3,6 @@ from coconut.tools import create_instance
 
 import numpy as np
 import unittest
-import matplotlib.pyplot as plt
-from matplotlib import cm
 
 
 class TestMapperDepth2DTo3D(unittest.TestCase):
@@ -118,6 +116,10 @@ class TestMapperDepth2DTo3D(unittest.TestCase):
 
         # extra: visualization
         if self.gui:
+            # import here to avoid error on systems without matplotlib
+            import matplotlib.pyplot as plt
+            from matplotlib import cm
+
             v_s_from, v_s_to = v_s_from.flatten(), v_s_to.flatten()
             c_from = cm.jet((v_s_from - v_s_from.min()) / (v_s_from.max() - v_s_from.min()))
             c_to = cm.jet((v_s_to - v_s_from.min()) / (v_s_from.max() - v_s_from.min()))

--- a/tests/mappers/test_depth_3d_to_2d.py
+++ b/tests/mappers/test_depth_3d_to_2d.py
@@ -4,8 +4,6 @@ from coconut.tests.mappers import test_depth_2d_to_3d
 
 import numpy as np
 import unittest
-import matplotlib.pyplot as plt
-from matplotlib import cm
 
 
 class TestMapperDepth3DTo2D(test_depth_2d_to_3d.TestMapperDepth2DTo3D):
@@ -73,6 +71,10 @@ class TestMapperDepth3DTo2D(test_depth_2d_to_3d.TestMapperDepth2DTo3D):
 
         # extra: visualization
         if self.gui:
+            # import here to avoid error on systems without matplotlib
+            import matplotlib.pyplot as plt
+            from matplotlib import cm
+
             v_s_from, v_s_to = v_s_from.flatten(), v_s_to.flatten()
             c_from = cm.jet((v_s_from - v_s_from.min()) / (v_s_from.max() - v_s_from.min()))
             c_to = cm.jet((v_s_to - v_s_from.min()) / (v_s_from.max() - v_s_from.min()))

--- a/tests/mappers/test_interpolator.py
+++ b/tests/mappers/test_interpolator.py
@@ -3,9 +3,12 @@ from coconut.tools import create_instance
 
 import unittest
 import numpy as np
-import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D
-from matplotlib import cm
+try:  # avoid error on systems without matplotlib
+    import matplotlib.pyplot as plt
+    from mpl_toolkits.mplot3d import Axes3D
+    from matplotlib import cm
+except ModuleNotFoundError:
+    pass
 
 
 def split(coords):


### PR DESCRIPTION
**Description** Fixes the problem that mapper tests return an error if the `matplotlib `package is not available.

**Users' experience affected?** The mapper tests can now succeed on a system without the `matplotlib` package, when using the SciPy-bundle for example.
It was observed that the  SciPy-bundle with foss toolchain can lead to a problem related to the `multiprocesing` package: when running all tests, it hangs in the `test_mapping_cylinder (coconut.tests.mappers.test_radial_basis.TestMapperRadialBasis)`. However this problem does not occur if only a subset of the tests is run.
As this does not occur for the SciPy-bundle with intel toolchain, it is recommended to use this, when Anaconda is not available.

**Other parts of the code affected?** No.

**Tests** Ran all fast tests.

**Related issues** Closes #144 

**Checklist**
- [x] Style guidelines
    1. CoCoNuT follows [the PEP8 style guide](https://www.python.org/dev/peps/pep-0008/).
    2. Comments should be lowercase.
    3. Errors should start with capitals, preferably without punctuation unless it's multiple sentences.
    4. Strings should use single quotes whenever possible.	
- [x] Self-review of code performed
- [x] Code has been commented (particularly in hard-to-understand areas)
- [x] Documentation was updated correspondingly
- [x] New and existing unit tests pass locally with changes
