### PR TITLE
Fluent logfiles

### DIFF
--- a/coupling_components/solver_wrappers/fluent/fluent.py
+++ b/coupling_components/solver_wrappers/fluent/fluent.py
@@ -348,9 +348,12 @@ class SolverWrapperFluent(Component):
     def finalize(self):
         super().finalize()
         shutil.rmtree(join('/tmp', self.tmp_directory_name), ignore_errors=True)
+        # delete log file (fluent.log is sufficient)
+        os.unlink(join(self.dir_cfd,'log'))
         self.send_message('stop')
         self.wait_message('stop_ready')
         self.fluent_process.wait()
+
 
     def get_interface_input(self):
         return self.interface_input

--- a/coupling_components/solver_wrappers/fluent/v2019R1.jou
+++ b/coupling_components/solver_wrappers/fluent/v2019R1.jou
@@ -1,6 +1,6 @@
 ;   GENERAL SETTINGS
-file set-batch-options n n n
-file start-transcript "transcript.txt"
+file set-batch-options n y n
+;file start-transcript "transcript.txt"
 (enable-dynamic-mesh-node-ids #t)
 ;file binary-files n
 (define unsteady |UNSTEADY|)

--- a/coupling_components/solver_wrappers/fluent/v2019R1.jou
+++ b/coupling_components/solver_wrappers/fluent/v2019R1.jou
@@ -1,5 +1,5 @@
 ;   GENERAL SETTINGS
-file set-batch-options n y n
+file set-batch-options n n n
 ;file start-transcript "transcript.txt"
 (enable-dynamic-mesh-node-ids #t)
 ;file binary-files n

--- a/coupling_components/solver_wrappers/fluent/v2019R2.jou
+++ b/coupling_components/solver_wrappers/fluent/v2019R2.jou
@@ -1,6 +1,6 @@
 ;   GENERAL SETTINGS
 file set-batch-options n n n
-file start-transcript "transcript.txt"
+;file start-transcript "transcript.txt"
 (enable-dynamic-mesh-node-ids #t)
 ;file binary-files n
 (define unsteady |UNSTEADY|)

--- a/coupling_components/solver_wrappers/fluent/v2019R3.jou
+++ b/coupling_components/solver_wrappers/fluent/v2019R3.jou
@@ -1,6 +1,6 @@
 ;   GENERAL SETTINGS
 file set-batch-options n n n
-file start-transcript "transcript.txt"
+;file start-transcript "transcript.txt"
 (enable-dynamic-mesh-node-ids #t)
 ;file binary-files n
 (define unsteady |UNSTEADY|)

--- a/coupling_components/solver_wrappers/fluent/v2020R1.jou
+++ b/coupling_components/solver_wrappers/fluent/v2020R1.jou
@@ -1,6 +1,6 @@
 ;   GENERAL SETTINGS
 file set-batch-options n n n
-file start-transcript "transcript.txt"
+;file start-transcript "transcript.txt"
 (enable-dynamic-mesh-node-ids #t)
 ;file binary-files n
 (define unsteady |UNSTEADY|)

--- a/coupling_components/solver_wrappers/fluent/v2021R1.jou
+++ b/coupling_components/solver_wrappers/fluent/v2021R1.jou
@@ -1,6 +1,6 @@
 ;   GENERAL SETTINGS
 file set-batch-options n n n
-file start-transcript "transcript.txt"
+;file start-transcript "transcript.txt"
 (enable-dynamic-mesh-node-ids #t)
 ;file binary-files n
 (define unsteady |UNSTEADY|)

--- a/examples/setup_files/breaking_dam/fluent2d/case.jou
+++ b/examples/setup_files/breaking_dam/fluent2d/case.jou
@@ -1,6 +1,6 @@
 file set-batch-options n y n
 (enable-dynamic-mesh-node-ids #t)
-file startt "transcript_setup.txt"
+;file startt "transcript_setup.txt"
 file read-case mesh_breaking_dam.msh
 grid check
 grid modify-zones zone-name default-interior fluid-interior

--- a/examples/setup_files/tube/fluent2d/case.jou
+++ b/examples/setup_files/tube/fluent2d/case.jou
@@ -1,6 +1,6 @@
 file set-batch-options n y n
 (enable-dynamic-mesh-node-ids #t)
-file startt "transcript_setup.txt"
+;file startt "transcript_setup.txt"
 file read-case mesh_tube2d.msh
 define models axisymmetric y
 grid check

--- a/examples/setup_files/tube/fluent2d_steady/case.jou
+++ b/examples/setup_files/tube/fluent2d_steady/case.jou
@@ -1,6 +1,6 @@
 file set-batch-options n y n
 (enable-dynamic-mesh-node-ids #t)
-file startt "transcript_setup.txt"
+;file startt "transcript_setup.txt"
 file read-case mesh_tube2d.msh
 define models axisymmetric y
 grid check

--- a/examples/setup_files/tube/fluent3d/case.jou
+++ b/examples/setup_files/tube/fluent3d/case.jou
@@ -1,6 +1,6 @@
 file set-batch-options n y n
 (enable-dynamic-mesh-node-ids #t)
-file startt "transcript_setup.txt"
+;file startt "transcript_setup.txt"
 file read-case mesh_tube3d.msh
 
 grid check

--- a/examples/setup_files/turek/fluent2d/case.jou
+++ b/examples/setup_files/turek/fluent2d/case.jou
@@ -1,6 +1,6 @@
 file set-batch-options n y n
 (enable-dynamic-mesh-node-ids #t)
-file startt "transcript_setup.txt"
+;file startt "transcript_setup.txt"
 file read-case mesh_turek.msh
 grid check
 grid modify-zones zone-name default-interior fluid-interior

--- a/examples/setup_files/turek/fluent2d_steady/case.jou
+++ b/examples/setup_files/turek/fluent2d_steady/case.jou
@@ -1,6 +1,6 @@
 file set-batch-options n y n
 (enable-dynamic-mesh-node-ids #t)
-file startt "transcript_setup.txt"
+;file startt "transcript_setup.txt"
 file read-case mesh_turek.msh
 grid check
 grid modify-zones zone-name default-interior fluid-interior

--- a/examples/tube_fluent2d_abaqus2d/setup_case.py
+++ b/examples/tube_fluent2d_abaqus2d/setup_case.py
@@ -1,5 +1,7 @@
 import shutil
 import subprocess
+import os
+from os.path import join
 
 from coconut import tools
 
@@ -24,3 +26,6 @@ subprocess.check_call('./setup_fluent2d.sh', shell=True, cwd=cfd_dir, env=cfd_en
 shutil.copytree('../setup_files/tube/abaqus2d', csm_dir)
 csm_env = tools.get_solver_env(csm_solver, csm_dir)
 subprocess.check_call('./setup_abaqus2d.sh', shell=True, cwd=csm_dir, env=csm_env)
+
+# delete log file (fluent.log is sufficient)
+os.unlink(join(cfd_dir,'log'))

--- a/examples/tube_fluent2d_abaqus2d/setup_case.py
+++ b/examples/tube_fluent2d_abaqus2d/setup_case.py
@@ -28,4 +28,4 @@ csm_env = tools.get_solver_env(csm_solver, csm_dir)
 subprocess.check_call('./setup_abaqus2d.sh', shell=True, cwd=csm_dir, env=csm_env)
 
 # delete log file (fluent.log is sufficient)
-os.unlink(join(cfd_dir,'log'))
+os.unlink(join(cfd_dir, 'log'))

--- a/examples/tube_fluent2d_tube_structure/setup_case.py
+++ b/examples/tube_fluent2d_tube_structure/setup_case.py
@@ -25,4 +25,4 @@ subprocess.check_call('./setup_fluent2d.sh', shell=True, cwd=cfd_dir, env=cfd_en
 shutil.copytree('../setup_files/tube/tube_structure', 'CSM')
 
 # delete log file (fluent.log is sufficient)
-os.unlink(join(cfd_dir,'log'))
+os.unlink(join(cfd_dir, 'log'))

--- a/examples/tube_fluent2d_tube_structure/setup_case.py
+++ b/examples/tube_fluent2d_tube_structure/setup_case.py
@@ -25,4 +25,4 @@ subprocess.check_call('./setup_fluent2d.sh', shell=True, cwd=cfd_dir, env=cfd_en
 shutil.copytree('../setup_files/tube/tube_structure', 'CSM')
 
 # delete log file (fluent.log is sufficient)
-os.unlink('./CFD/log')
+os.unlink(join(cfd_dir,'log'))

--- a/examples/tube_fluent2d_tube_structure/setup_case.py
+++ b/examples/tube_fluent2d_tube_structure/setup_case.py
@@ -1,5 +1,7 @@
 import shutil
 import subprocess
+import os
+from os.path import join
 
 from coconut import tools
 
@@ -21,3 +23,6 @@ subprocess.check_call('./setup_fluent2d.sh', shell=True, cwd=cfd_dir, env=cfd_en
 
 # create new CSM folder
 shutil.copytree('../setup_files/tube/tube_structure', 'CSM')
+
+# delete log file (fluent.log is sufficient)
+os.unlink('./CFD/log')

--- a/examples/tube_fluent3d_abaqus2d/setup_case.py
+++ b/examples/tube_fluent3d_abaqus2d/setup_case.py
@@ -1,7 +1,7 @@
 import shutil
 import subprocess
 import os
-from os.path import jion
+from os.path import join
 
 from coconut import tools
 
@@ -28,4 +28,4 @@ csm_env = tools.get_solver_env(csm_solver, csm_dir)
 subprocess.check_call('./setup_abaqus2d.sh', shell=True, cwd=csm_dir, env=csm_env)
 
 # delete log file (fluent.log is sufficient)
-os.unlink(join(cfd_dir,'log'))
+os.unlink(join(cfd_dir, 'log'))

--- a/examples/tube_fluent3d_abaqus2d/setup_case.py
+++ b/examples/tube_fluent3d_abaqus2d/setup_case.py
@@ -1,5 +1,7 @@
 import shutil
 import subprocess
+import os
+from os.path import jion
 
 from coconut import tools
 
@@ -24,3 +26,6 @@ subprocess.check_call('./setup_fluent3d.sh', shell=True, cwd=cfd_dir, env=cfd_en
 shutil.copytree('../setup_files/tube/abaqus2d', csm_dir)
 csm_env = tools.get_solver_env(csm_solver, csm_dir)
 subprocess.check_call('./setup_abaqus2d.sh', shell=True, cwd=csm_dir, env=csm_env)
+
+# delete log file (fluent.log is sufficient)
+os.unlink(join(cfd_dir,'log'))

--- a/examples/tube_fluent3d_abaqus3d/setup_case.py
+++ b/examples/tube_fluent3d_abaqus3d/setup_case.py
@@ -28,4 +28,4 @@ csm_env = tools.get_solver_env(csm_solver, csm_dir)
 subprocess.check_call('./setup_abaqus3d.sh', shell=True, cwd=csm_dir, env=csm_env)
 
 # delete log file (fluent.log is sufficient)
-os.unlink(join(cfd_dir,'log'))
+os.unlink(join(cfd_dir, 'log'))

--- a/examples/tube_fluent3d_abaqus3d/setup_case.py
+++ b/examples/tube_fluent3d_abaqus3d/setup_case.py
@@ -1,5 +1,7 @@
 import shutil
 import subprocess
+import os
+from os.path import join
 
 from coconut import tools
 
@@ -24,3 +26,6 @@ subprocess.check_call('./setup_fluent3d.sh', shell=True, cwd=cfd_dir, env=cfd_en
 shutil.copytree('../setup_files/tube/abaqus3d', csm_dir)
 csm_env = tools.get_solver_env(csm_solver, csm_dir)
 subprocess.check_call('./setup_abaqus3d.sh', shell=True, cwd=csm_dir, env=csm_env)
+
+# delete log file (fluent.log is sufficient)
+os.unlink(join(cfd_dir,'log'))

--- a/examples/tube_fluent3d_kratos_structure3d/setup_case.py
+++ b/examples/tube_fluent3d_kratos_structure3d/setup_case.py
@@ -26,4 +26,4 @@ subprocess.check_call('./setup_fluent3d.sh', shell=True, cwd=cfd_dir, env=cfd_en
 shutil.copytree('../setup_files/tube/kratos_structure3d', csm_dir)
 
 # delete log file (fluent.log is sufficient)
-os.unlink(join(cfd_dir,'log'))
+os.unlink(join(cfd_dir, 'log'))

--- a/examples/tube_fluent3d_kratos_structure3d/setup_case.py
+++ b/examples/tube_fluent3d_kratos_structure3d/setup_case.py
@@ -1,5 +1,7 @@
 import shutil
 import subprocess
+import os
+from os.path import join
 
 from coconut import tools
 
@@ -22,3 +24,6 @@ subprocess.check_call('./setup_fluent3d.sh', shell=True, cwd=cfd_dir, env=cfd_en
 
 # create new CSM folder
 shutil.copytree('../setup_files/tube/kratos_structure3d', csm_dir)
+
+# delete log file (fluent.log is sufficient)
+os.unlink(join(cfd_dir,'log'))

--- a/examples/turek_fluent2d_abaqus2d/setup_case.py
+++ b/examples/turek_fluent2d_abaqus2d/setup_case.py
@@ -1,5 +1,7 @@
 import shutil
 import subprocess
+import os
+from os.path import join
 
 from coconut import tools
 
@@ -24,3 +26,6 @@ subprocess.check_call('./setup_fluent2d.sh', shell=True, cwd=cfd_dir, env=cfd_en
 shutil.copytree('../setup_files/turek/abaqus2d', csm_dir)
 csm_env = tools.get_solver_env(csm_solver, csm_dir)
 subprocess.check_call('./setup_abaqus2d.sh', shell=True, cwd=csm_dir, env=csm_env)
+
+# delete log file (fluent.log is sufficient)
+os.unlink(join(cfd_dir,'log'))

--- a/examples/turek_fluent2d_abaqus2d/setup_case.py
+++ b/examples/turek_fluent2d_abaqus2d/setup_case.py
@@ -28,4 +28,4 @@ csm_env = tools.get_solver_env(csm_solver, csm_dir)
 subprocess.check_call('./setup_abaqus2d.sh', shell=True, cwd=csm_dir, env=csm_env)
 
 # delete log file (fluent.log is sufficient)
-os.unlink(join(cfd_dir,'log'))
+os.unlink(join(cfd_dir, 'log'))


### PR DESCRIPTION
**Description** 

1.  The file "log" is deleted at the end and  transcript.txt files are not written anymore. fluent.log is kept and contains all the information.
2.  An error is raised when the wrong dimension is used in the JSON file. Fluent.log files are not appended anymore to previous fluent.log files. Instead, the fluent.log file from the previous calculation is renamed to fluent_backup.log.

**Users' experience affected?**  No.

**Other parts of the code affected?** No.

**Tests**  Tested with example cases.

**Related issues** 
Closes #141
Closes #102

**Checklist**
- [X] Style guidelines
    1. CoCoNuT follows [the PEP8 style guide](https://www.python.org/dev/peps/pep-0008/).
    2. Comments should be lowercase.
    3. Errors should start with capitals, preferably without punctuation unless it's multiple sentences.
    4. Strings should use single quotes whenever possible.	
- [X] Self-review of code performed
- [X] Code has been commented (particularly in hard-to-understand areas)
- [x] Documentation was updated correspondingly
- [x] New and existing unit tests pass locally with changes
