### PR TITLE
Fluent save_results and save_restart

### DIFF
--- a/coupling_components/solver_wrappers/fluent/fluent.md
+++ b/coupling_components/solver_wrappers/fluent/fluent.md
@@ -31,7 +31,7 @@ parameter|type|description
 `interface_output`|dict|Analogous to `interface_input`, but for the output `Interface` (Fluent faces). Each `ModelPart` name must be the concatenation of an entry from the file `thread_names` and "_faces".
 `max_nodes_per_face`|int|This value is used to construct unique IDs for faces, based on unique IDs of nodes (provided by Fluent). It should be at least as high as the maximum number of nodes on a face on the interface. Use e.g. 4 for rectangular faces, 3 for triangular faces and 2 in 2D simulations (edges).
 `multiphase`|bool|(optional) Default `false`. `true` for multiphase Fluent case, `false` for singlephase.
-`save_iterations`|int|Number of time steps between consecutive saves of the Fluent case and data files.
+`save_results`|int|Number of time steps between consecutive saves of the Fluent case and data files.
 `thread_names`|list|List with Fluent names of the surface threads on the FSI interface. 
 `timestep_start`|int|Time step number to (re)start a transient FSI calculation. If 0 is given, the simulation starts from the `case_file`, else the code looks for the relevant case and data files. This parameter is usually specified in a higher `Component`.
 `unsteady`|bool|`true` for transient FSI, `false` for steady FSI.

--- a/examples/breaking_dam_fluent2d_abaqus2d/parameters.json
+++ b/examples/breaking_dam_fluent2d_abaqus2d/parameters.json
@@ -102,7 +102,7 @@
           "fluent_gui": false,
           "max_nodes_per_face": 2,
           "flow_iterations": 500,
-          "save_iterations": 1
+          "save_results": 1
         }
       },
       {

--- a/examples/test_single_solver/parameters.json
+++ b/examples/test_single_solver/parameters.json
@@ -77,7 +77,7 @@
           "fluent_gui": false,
           "max_nodes_per_face": 4,
           "flow_iterations": 200,
-          "save_iterations": 1
+          "save_results": 1
         }
       },
       {

--- a/examples/tube_fluent2d_abaqus2d_steady/parameters.json
+++ b/examples/tube_fluent2d_abaqus2d_steady/parameters.json
@@ -72,7 +72,7 @@
           "fluent_gui": false,
           "max_nodes_per_face": 2,
           "flow_iterations": 200,
-          "save_iterations": 1
+          "save_results": 1
         }
       },
       {

--- a/examples/tube_fluent2d_tube_structure/parameters.json
+++ b/examples/tube_fluent2d_tube_structure/parameters.json
@@ -72,7 +72,7 @@
           "fluent_gui": false,
           "max_nodes_per_face": 2,
           "flow_iterations": 200,
-          "save_iterations": 1
+          "save_results": 1
         }
       },
       {

--- a/examples/tube_fluent3d_abaqus2d/parameters.json
+++ b/examples/tube_fluent3d_abaqus2d/parameters.json
@@ -72,7 +72,7 @@
           "fluent_gui": false,
           "max_nodes_per_face": 4,
           "flow_iterations": 200,
-          "save_iterations": 1
+          "save_results": 1
         }
       },
       {

--- a/examples/tube_fluent3d_abaqus3d/parameters.json
+++ b/examples/tube_fluent3d_abaqus3d/parameters.json
@@ -72,7 +72,7 @@
           "fluent_gui": false,
           "max_nodes_per_face": 4,
           "flow_iterations": 200,
-          "save_iterations": 1
+          "save_results": 1
         }
       },
       {

--- a/examples/tube_fluent3d_kratos_structure3d/parameters.json
+++ b/examples/tube_fluent3d_kratos_structure3d/parameters.json
@@ -72,7 +72,7 @@
           "fluent_gui": false,
           "max_nodes_per_face": 4,
           "flow_iterations": 200,
-          "save_iterations": 1
+          "save_results": 1
         }
       },
       {

--- a/examples/turek_fluent2d_abaqus2d/parameters.json
+++ b/examples/turek_fluent2d_abaqus2d/parameters.json
@@ -101,8 +101,8 @@
           "cores": 8,
           "fluent_gui": false,
           "max_nodes_per_face": 2,
-          "flow_iterations": 200,
-          "save_iterations": 50
+          "flow_iterations": 20,
+          "save_results": 0
         }
       },
       {

--- a/examples/turek_fluent2d_abaqus2d_steady/parameters.json
+++ b/examples/turek_fluent2d_abaqus2d_steady/parameters.json
@@ -101,7 +101,7 @@
           "fluent_gui": false,
           "max_nodes_per_face": 2,
           "flow_iterations": 1000,
-          "save_iterations": 1
+          "save_results": 1
         }
       },
       {

--- a/tests/solver_wrappers/fluent/test_v2019R1/tube2d/parameters.json
+++ b/tests/solver_wrappers/fluent/test_v2019R1/tube2d/parameters.json
@@ -31,6 +31,6 @@
     "fluent_gui": false,
     "max_nodes_per_face": 2,
     "flow_iterations": 200,
-    "save_iterations": 1
+    "save_results": 1
   }
 }

--- a/tests/solver_wrappers/fluent/test_v2019R1/tube3d/parameters.json
+++ b/tests/solver_wrappers/fluent/test_v2019R1/tube3d/parameters.json
@@ -31,6 +31,6 @@
     "fluent_gui": false,
     "max_nodes_per_face": 4,
     "flow_iterations": 200,
-    "save_iterations": 1
+    "save_results": 1
   }
 }

--- a/tests/solver_wrappers/fluent/test_v2019R2/tube2d/parameters.json
+++ b/tests/solver_wrappers/fluent/test_v2019R2/tube2d/parameters.json
@@ -31,6 +31,6 @@
     "fluent_gui": false,
     "max_nodes_per_face": 2,
     "flow_iterations": 200,
-    "save_iterations": 1
+    "save_results": 1
   }
 }

--- a/tests/solver_wrappers/fluent/test_v2019R2/tube3d/parameters.json
+++ b/tests/solver_wrappers/fluent/test_v2019R2/tube3d/parameters.json
@@ -31,6 +31,6 @@
     "fluent_gui": false,
     "max_nodes_per_face": 4,
     "flow_iterations": 200,
-    "save_iterations": 1
+    "save_results": 1
   }
 }

--- a/tests/solver_wrappers/fluent/test_v2019R3/tube2d/parameters.json
+++ b/tests/solver_wrappers/fluent/test_v2019R3/tube2d/parameters.json
@@ -31,6 +31,6 @@
     "fluent_gui": false,
     "max_nodes_per_face": 2,
     "flow_iterations": 200,
-    "save_iterations": 1
+    "save_results": 1
   }
 }

--- a/tests/solver_wrappers/fluent/test_v2019R3/tube3d/parameters.json
+++ b/tests/solver_wrappers/fluent/test_v2019R3/tube3d/parameters.json
@@ -31,6 +31,6 @@
     "fluent_gui": false,
     "max_nodes_per_face": 4,
     "flow_iterations": 200,
-    "save_iterations": 1
+    "save_results": 1
   }
 }

--- a/tests/solver_wrappers/fluent/test_v2020R1/tube2d/parameters.json
+++ b/tests/solver_wrappers/fluent/test_v2020R1/tube2d/parameters.json
@@ -31,6 +31,6 @@
     "fluent_gui": false,
     "max_nodes_per_face": 2,
     "flow_iterations": 200,
-    "save_iterations": 1
+    "save_results": 1
   }
 }

--- a/tests/solver_wrappers/fluent/test_v2020R1/tube3d/parameters.json
+++ b/tests/solver_wrappers/fluent/test_v2020R1/tube3d/parameters.json
@@ -31,6 +31,6 @@
     "fluent_gui": false,
     "max_nodes_per_face": 4,
     "flow_iterations": 200,
-    "save_iterations": 1
+    "save_results": 1
   }
 }

--- a/tests/solver_wrappers/fluent/test_v2021R1/tube2d/parameters.json
+++ b/tests/solver_wrappers/fluent/test_v2021R1/tube2d/parameters.json
@@ -31,6 +31,6 @@
     "fluent_gui": false,
     "max_nodes_per_face": 2,
     "flow_iterations": 200,
-    "save_iterations": 1
+    "save_results": 1
   }
 }

--- a/tests/solver_wrappers/fluent/test_v2021R1/tube3d/parameters.json
+++ b/tests/solver_wrappers/fluent/test_v2021R1/tube3d/parameters.json
@@ -31,6 +31,6 @@
     "fluent_gui": false,
     "max_nodes_per_face": 4,
     "flow_iterations": 200,
-    "save_iterations": 1
+    "save_results": 1
   }
 }


### PR DESCRIPTION
**Description** 
- `save_iterations` replaced by `save_results`
- case and data files saved when timestep is multiple of either `save_results` or `save_restart`
- unnecessary files deleted:
     - nodes_update and pressure_traction .dat files
     - case and data files when new case and data files are written by `save_restart` (when `save_restart < 0`, and when not saved by `save_results`)
     - .trn files
 
**Users' experience affected?** 
- `save_iterations` are no longer an option, replaced by `save_results`. `save_results` should be defined under the corresponding solver_wrapper.
-  `save_results` default value is 1

**Other parts of the code affected?**  No.

**Tests** 
Several examples are testes (turek_2d_abaqus2d, tube_fluent2d, tube_fluent 3d) with several different options for `save_restart` and `save_results`.

**Related issues** 
#103 Saving interval and restart interval (Fluent)

**Checklist**
- [ ] Style guidelines
    1. CoCoNuT follows [the PEP8 style guide](https://www.python.org/dev/peps/pep-0008/).
    2. Comments should be lowercase.
    3. Errors should start with capitals, preferably without punctuation unless it's multiple sentences.
    4. Strings should use single quotes whenever possible.	
- [X] Self-review of code performed
- [X] Code has been commented (particularly in hard-to-understand areas)
- [X] Documentation was updated correspondingly
- [ ] New and existing unit tests pass locally with changes
