### PR TITLE
Fluent multinode + BrENIAC machine

### DIFF
--- a/coupling_components/solver_wrappers/abaqus/abaqus.py
+++ b/coupling_components/solver_wrappers/abaqus/abaqus.py
@@ -40,7 +40,8 @@ class SolverWrapperAbaqus(Component):
         self.vault_suffixes = ['023', 'com', 'dat', 'mdl', 'msg', 'odb', 'prt', 'res', 'sim', 'stt']
         self.path_src = os.path.realpath(os.path.dirname(__file__))
         self.logfile = 'abaqus.log'
-        self.tmp_directory_name = f'coconut_{getuser()}_{os.getpid()}_abaqus'  # dir in /tmp for host-node communication
+        self.tmp_dir = os.environ.get('TMPDIR', '/tmp') # dir for host-node communication
+        self.tmp_dir_unique = os.path.join(self.tmp_dir, f'coconut_{getuser()}_{os.getpid()}_abaqus')
 
         self.cores = self.settings['cores']  # number of CPUs Abaqus has to use
         self.dimensions = self.settings['dimensions']
@@ -98,7 +99,7 @@ class SolverWrapperAbaqus(Component):
                     line = line.replace('|HOSTNAME|', hostname_replace) if self.mp_mode == 'MPI' \
                         else (line, '')['|HOSTNAME|' in line]  # replace |HOSTNAME| if MPI else remove line
                     line = line.replace('|MP_MODE|', self.mp_mode)
-                    line = line.replace('|TMP_DIRECTORY_NAME|', join('/tmp', self.tmp_directory_name))
+                    line = line.replace('|TMP_DIRECTORY_NAME|', join('/tmp', self.tmp_dir_unique))
                     line = line.replace('|LINK_SL|', self.link_sl) if self.link_sl is not None \
                         else (line, '')['|LINK_SL|' in line]  # replace |LINK_SL| if needed, else remove line
                     line = line.replace('|LINK_EXE|', self.link_exe) if self.link_exe is not None \
@@ -116,8 +117,8 @@ class SolverWrapperAbaqus(Component):
         path_libusr = join(self.dir_csm, 'libusr/')
         shutil.rmtree(path_libusr, ignore_errors=True)  # needed if restart
         os.mkdir(path_libusr)
-        shutil.rmtree(join('/tmp', self.tmp_directory_name), ignore_errors=True)
-        os.mkdir(join('/tmp', self.tmp_directory_name))  # create tmp-directory
+        shutil.rmtree(join('/tmp', self.tmp_dir_unique), ignore_errors=True)
+        os.mkdir(join('/tmp', self.tmp_dir_unique))  # create tmp-directory
 
         # prepare Abaqus USRInit.f
         if self.timestep_start == 0:  # run USRInit only for new calculation

--- a/coupling_components/solver_wrappers/fluent/fluent.md
+++ b/coupling_components/solver_wrappers/fluent/fluent.md
@@ -21,7 +21,7 @@ This section describes the parameters in the JSON file, listed in alphabetical o
 parameter|type|description
 ---:|:---:|---
 `case_file`|str|Name of the case file. It must be present in the folder specified by `working_directory`. The corresponding data file must also be present but has no key in the JSON file.
-`cores`|int|Number of processor cores to use when running Fluent (tested only on single node so far).
+`cores`|int|Total number of processor cores to use when running Fluent. When its value is negative or bigger than the maximum number of available cores, it will be automatically replaced by the maximum numver of available cores.
 `dimensions`|int|Dimension used in flow solver: `2` for 2D and axisymmetric, `3` for 3D. 
 `delta_t`|float|Fixed time step size in flow solver. This parameter is usually specified in a higher `Component`.
 <nobr>`end_of_timestep_commands`</nobr>|str|Fluent journal command(s) to be executed after every time step, to store drag and lift forces for example.

--- a/coupling_components/solver_wrappers/fluent/fluent.md
+++ b/coupling_components/solver_wrappers/fluent/fluent.md
@@ -28,6 +28,7 @@ parameter|type|description
 `flow_iterations`|int|Number of non-linear iterations in Fluent per coupling iteration.
 `fluent_gui`|bool|Set to `true` to run Fluent with the graphical interface.
 `interface_input`|list|List of dictionaries to describe the input `Interface` (Fluent nodes). Each dictionary defines one `ModelPart` with two keys: `model_part` contains the name of the `ModelPart` and `variables` contains a list of variable names. Each `ModelPart` name must be the concatenation of an entry from `thread_names` and "_nodes". The variable names must be chosen from *`data_structure/variables.py`*. 
+`hostfile`|str/bool|(optional) Default `false`. Filename of the hostfile in case of a multi-node job, this file has to be in the `working_directory` and contain the names of the available machines.
 `interface_output`|dict|Analogous to `interface_input`, but for the output `Interface` (Fluent faces). Each `ModelPart` name must be the concatenation of an entry from the file `thread_names` and "_faces".
 `max_nodes_per_face`|int|This value is used to construct unique IDs for faces, based on unique IDs of nodes (provided by Fluent). It should be at least as high as the maximum number of nodes on a face on the interface. Use e.g. 4 for rectangular faces, 3 for triangular faces and 2 in 2D simulations (edges).
 `multiphase`|bool|(optional) Default `false`. `true` for multiphase Fluent case, `false` for singlephase.

--- a/coupling_components/solver_wrappers/fluent/fluent.md
+++ b/coupling_components/solver_wrappers/fluent/fluent.md
@@ -28,7 +28,7 @@ parameter|type|description
 `flow_iterations`|int|Number of non-linear iterations in Fluent per coupling iteration.
 `fluent_gui`|bool|Set to `true` to run Fluent with the graphical interface.
 `interface_input`|list|List of dictionaries to describe the input `Interface` (Fluent nodes). Each dictionary defines one `ModelPart` with two keys: `model_part` contains the name of the `ModelPart` and `variables` contains a list of variable names. Each `ModelPart` name must be the concatenation of an entry from `thread_names` and "_nodes". The variable names must be chosen from *`data_structure/variables.py`*. 
-`hostfile`|str/bool|(optional) Default `false`. Filename of the hostfile in case of a multi-node job, this file has to be in the `working_directory` and contain the names of the available machines.
+`hostfile`|str|(optional) Filename of the hostfile in case of a multi-node job, this file has to be in the `working_directory` and contain the names of the available machines. Not required for single-node jobs.
 `interface_output`|dict|Analogous to `interface_input`, but for the output `Interface` (Fluent faces). Each `ModelPart` name must be the concatenation of an entry from the file `thread_names` and "_faces".
 `max_nodes_per_face`|int|This value is used to construct unique IDs for faces, based on unique IDs of nodes (provided by Fluent). It should be at least as high as the maximum number of nodes on a face on the interface. Use e.g. 4 for rectangular faces, 3 for triangular faces and 2 in 2D simulations (edges).
 `multiphase`|bool|(optional) Default `false`. `true` for multiphase Fluent case, `false` for singlephase.

--- a/coupling_components/solver_wrappers/fluent/fluent.py
+++ b/coupling_components/solver_wrappers/fluent/fluent.py
@@ -125,7 +125,7 @@ class SolverWrapperFluent(Component):
         cmd2 = f'-t{self.cores} -i {journal}'
 
         if self.hostfile:
-            cmd2 += f' -cnf={self.hostfile} -ssh'
+            cmd1 += f' -cnf={self.hostfile} -ssh'
         if self.settings['fluent_gui']:
             cmd = cmd1 + cmd2
         else:

--- a/coupling_components/solver_wrappers/fluent/fluent.py
+++ b/coupling_components/solver_wrappers/fluent/fluent.py
@@ -44,8 +44,13 @@ class SolverWrapperFluent(Component):
         self.tmp_directory_name = f'coconut_{getuser()}_{os.getpid()}_fluent'  # dir in /tmp for host-node communication
         self.cores = self.settings['cores']
         self.hostfile = self.settings.get('hostfile', False)
-        if self.cores < 1 or (self.cores > multiprocessing.cpu_count() and not self.hostfile):
-            self.cores = multiprocessing.cpu_count()  # TODO: add this behavior to documentation
+        if self.hostfile:
+            with open(self.hostfile) as fp:
+                max_cores = len(fp.readlines())
+        else:
+            max_cores = multiprocessing.cpu_count()
+        if self.cores < 1 or self.cores > max_cores:
+            self.cores = max_cores
         self.case_file = self.settings['case_file']
         self.data_file = self.case_file.replace('.cas', '.dat', 1)
         if not os.path.exists(os.path.join(self.dir_cfd, self.case_file)):

--- a/coupling_components/solver_wrappers/fluent/fluent.py
+++ b/coupling_components/solver_wrappers/fluent/fluent.py
@@ -43,9 +43,9 @@ class SolverWrapperFluent(Component):
         self.dir_src = os.path.realpath(os.path.dirname(__file__))
         self.tmp_directory_name = f'coconut_{getuser()}_{os.getpid()}_fluent'  # dir in /tmp for host-node communication
         self.cores = self.settings['cores']
-        if self.cores < 1 or self.cores > multiprocessing.cpu_count():
-            self.cores = multiprocessing.cpu_count()  # TODO: add this behavior to documentation
         self.hostfile = self.settings.get('hostfile', False)
+        if self.cores < 1 or (self.cores > multiprocessing.cpu_count() and not self.hostfile):
+            self.cores = multiprocessing.cpu_count()  # TODO: add this behavior to documentation
         self.case_file = self.settings['case_file']
         self.data_file = self.case_file.replace('.cas', '.dat', 1)
         if not os.path.exists(os.path.join(self.dir_cfd, self.case_file)):

--- a/coupling_components/solver_wrappers/fluent/fluent.py
+++ b/coupling_components/solver_wrappers/fluent/fluent.py
@@ -41,7 +41,8 @@ class SolverWrapperFluent(Component):
         self.remove_all_messages()
         self.backup_fluent_log()
         self.dir_src = os.path.realpath(os.path.dirname(__file__))
-        self.tmp_directory_name = f'coconut_{getuser()}_{os.getpid()}_fluent'  # dir in /tmp for host-node communication
+        self.tmp_dir = os.environ.get('TMPDIR', '/tmp') # dir for host-node communication
+        self.tmp_dir_unique = os.path.join(self.tmp_dir, f'coconut_{getuser()}_{os.getpid()}_fluent')
         self.cores = self.settings['cores']
         self.hostfile = self.settings.get('hostfile')
         self.case_file = self.settings['case_file']
@@ -112,7 +113,7 @@ class SolverWrapperFluent(Component):
             with open(join(self.dir_cfd, udf), 'w') as outfile:
                 for line in infile:
                     line = line.replace('|MAX_NODES_PER_FACE|', str(self.mnpf))
-                    line = line.replace('|TMP_DIRECTORY_NAME|', self.tmp_directory_name)
+                    line = line.replace('|TMP_DIRECTORY_NAME|', self.tmp_dir_unique)
                     outfile.write(line)
 
         # check number of cores
@@ -387,7 +388,7 @@ class SolverWrapperFluent(Component):
 
     def finalize(self):
         super().finalize()
-        shutil.rmtree(join('/tmp', self.tmp_directory_name), ignore_errors=True)
+        shutil.rmtree(join('/tmp', self.tmp_dir_unique), ignore_errors=True)
         self.send_message('stop')
         self.wait_message('stop_ready')
         self.fluent_process.wait()

--- a/coupling_components/solver_wrappers/fluent/fluent.py
+++ b/coupling_components/solver_wrappers/fluent/fluent.py
@@ -125,7 +125,7 @@ class SolverWrapperFluent(Component):
         cmd2 = f'-t{self.cores} -i {journal}'
 
         if self.hostfile:
-            cmd1 += f' -cnf={self.hostfile} -ssh'
+            cmd1 += f' -cnf={self.hostfile} -ssh '
         if self.settings['fluent_gui']:
             cmd = cmd1 + cmd2
         else:

--- a/coupling_components/solver_wrappers/fluent/fluent.py
+++ b/coupling_components/solver_wrappers/fluent/fluent.py
@@ -108,8 +108,6 @@ class SolverWrapperFluent(Component):
 
         # prepare Fluent UDF
         udf = f'v{self.version}.c'
-        shutil.rmtree(join('/tmp', self.tmp_directory_name), ignore_errors=True)
-        os.mkdir(join('/tmp', self.tmp_directory_name))
         with open(join(self.dir_src, udf)) as infile:
             with open(join(self.dir_cfd, udf), 'w') as outfile:
                 for line in infile:

--- a/coupling_components/solver_wrappers/fluent/fluent.py
+++ b/coupling_components/solver_wrappers/fluent/fluent.py
@@ -119,7 +119,7 @@ class SolverWrapperFluent(Component):
 
         # check number of cores
         if self.hostfile:
-            with open(self.hostfile) as fp:
+            with open(join(self.working_directory, self.hostfile)) as fp:
                 max_cores = len(fp.readlines())
         else:
             max_cores = multiprocessing.cpu_count()

--- a/coupling_components/solver_wrappers/fluent/fluent.py
+++ b/coupling_components/solver_wrappers/fluent/fluent.py
@@ -119,7 +119,7 @@ class SolverWrapperFluent(Component):
 
         # check number of cores
         if self.hostfile:
-            with open(join(self.working_directory, self.hostfile)) as fp:
+            with open(join(self.dir_cfd, self.hostfile)) as fp:
                 max_cores = len(fp.readlines())
         else:
             max_cores = multiprocessing.cpu_count()

--- a/coupling_components/solver_wrappers/fluent/fluent.py
+++ b/coupling_components/solver_wrappers/fluent/fluent.py
@@ -45,6 +45,7 @@ class SolverWrapperFluent(Component):
         self.cores = self.settings['cores']
         if self.cores < 1 or self.cores > multiprocessing.cpu_count():
             self.cores = multiprocessing.cpu_count()  # TODO: add this behavior to documentation
+        self.hostfile = self.settings.get('hostfile', False)
         self.case_file = self.settings['case_file']
         self.data_file = self.case_file.replace('.cas', '.dat', 1)
         if not os.path.exists(os.path.join(self.dir_cfd, self.case_file)):
@@ -123,6 +124,8 @@ class SolverWrapperFluent(Component):
         cmd1 = f'fluent -r{self.version_bis} {self.dimensions}ddp '
         cmd2 = f'-t{self.cores} -i {journal}'
 
+        if self.hostfile:
+            cmd2 += f' -cnf={self.hostfile} -ssh'
         if self.settings['fluent_gui']:
             cmd = cmd1 + cmd2
         else:

--- a/coupling_components/solver_wrappers/fluent/fluent.py
+++ b/coupling_components/solver_wrappers/fluent/fluent.py
@@ -44,13 +44,6 @@ class SolverWrapperFluent(Component):
         self.tmp_directory_name = f'coconut_{getuser()}_{os.getpid()}_fluent'  # dir in /tmp for host-node communication
         self.cores = self.settings['cores']
         self.hostfile = self.settings.get('hostfile', False)
-        if self.hostfile:
-            with open(self.hostfile) as fp:
-                max_cores = len(fp.readlines())
-        else:
-            max_cores = multiprocessing.cpu_count()
-        if self.cores < 1 or self.cores > max_cores:
-            self.cores = max_cores
         self.case_file = self.settings['case_file']
         self.data_file = self.case_file.replace('.cas', '.dat', 1)
         if not os.path.exists(os.path.join(self.dir_cfd, self.case_file)):
@@ -123,6 +116,16 @@ class SolverWrapperFluent(Component):
                     line = line.replace('|MAX_NODES_PER_FACE|', str(self.mnpf))
                     line = line.replace('|TMP_DIRECTORY_NAME|', self.tmp_directory_name)
                     outfile.write(line)
+
+        # check number of cores
+        if self.hostfile:
+            with open(self.hostfile) as fp:
+                max_cores = len(fp.readlines())
+        else:
+            max_cores = multiprocessing.cpu_count()
+        if self.cores < 1 or self.cores > max_cores:
+            tools.print_info(f'Number of cores not possible, changed from {self.cores} to {max_cores}')
+            self.cores = max_cores
 
         # start Fluent with journal
         log = join(self.dir_cfd, 'fluent.log')

--- a/coupling_components/solver_wrappers/fluent/fluent.py
+++ b/coupling_components/solver_wrappers/fluent/fluent.py
@@ -43,7 +43,7 @@ class SolverWrapperFluent(Component):
         self.dir_src = os.path.realpath(os.path.dirname(__file__))
         self.tmp_directory_name = f'coconut_{getuser()}_{os.getpid()}_fluent'  # dir in /tmp for host-node communication
         self.cores = self.settings['cores']
-        self.hostfile = self.settings.get('hostfile', False)
+        self.hostfile = self.settings.get('hostfile')
         self.case_file = self.settings['case_file']
         self.data_file = self.case_file.replace('.cas', '.dat', 1)
         if not os.path.exists(os.path.join(self.dir_cfd, self.case_file)):
@@ -116,7 +116,7 @@ class SolverWrapperFluent(Component):
                     outfile.write(line)
 
         # check number of cores
-        if self.hostfile:
+        if self.hostfile is not None:
             with open(join(self.dir_cfd, self.hostfile)) as fp:
                 max_cores = len(fp.readlines())
         else:
@@ -130,7 +130,7 @@ class SolverWrapperFluent(Component):
         cmd1 = f'fluent -r{self.version_bis} {self.dimensions}ddp '
         cmd2 = f'-t{self.cores} -i {journal}'
 
-        if self.hostfile:
+        if self.hostfile is not None:
             cmd1 += f' -cnf={self.hostfile} -ssh '
         if self.settings['fluent_gui']:
             cmd = cmd1 + cmd2

--- a/coupling_components/solver_wrappers/fluent/fluent.py
+++ b/coupling_components/solver_wrappers/fluent/fluent.py
@@ -122,7 +122,7 @@ class SolverWrapperFluent(Component):
         else:
             max_cores = multiprocessing.cpu_count()
         if self.cores < 1 or self.cores > max_cores:
-            tools.print_info(f'Number of cores not possible, changed from {self.cores} to {max_cores}')
+            tools.print_info(f'Number of cores incorrect, changed from {self.cores} to {max_cores}', layout='warning')
             self.cores = max_cores
 
         # start Fluent with journal

--- a/coupling_components/solver_wrappers/fluent/v2019R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2019R1.c
@@ -555,4 +555,3 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 
     if (myid == 0) {printf("\nFinished UDF move_nodes.\n"); fflush(stdout);}
 }
-

--- a/coupling_components/solver_wrappers/fluent/v2019R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2019R1.c
@@ -1,6 +1,8 @@
 #include "udf.h"
 #include <math.h>
-
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 /* dynamic memory allocation for 1D and 2D arrays */
 #define DECLARE_MEMORY(name, type) type *name = NULL
@@ -498,6 +500,11 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     sprintf(file_name, "nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
 #else
+    struct stat st = {0};
+
+    if (stat("/tmp/|TMP_DIRECTORY_NAME|", &st) == -1) {
+        mkdir("/tmp/|TMP_DIRECTORY_NAME|", 0700);
+    }
     sprintf(file_name, "/tmp/|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
     host_to_node_sync_file("/tmp/|TMP_DIRECTORY_NAME|");

--- a/coupling_components/solver_wrappers/fluent/v2019R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2019R1.c
@@ -560,5 +560,9 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     RELEASE_MEMORY(ids);
 #endif /* !RP_HOST */
 
+#if RP_NODE
+    remove(file_name);
+#endif /* RP_NODE */
+
     if (myid == 0) {printf("\nFinished UDF move_nodes.\n"); fflush(stdout);}
 }

--- a/coupling_components/solver_wrappers/fluent/v2019R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2019R1.c
@@ -502,12 +502,12 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #else
     struct stat st = {0};
 
-    if (stat("/tmp/|TMP_DIRECTORY_NAME|", &st) == -1) {
-        mkdir("/tmp/|TMP_DIRECTORY_NAME|", 0700);
+    if (stat("|TMP_DIRECTORY_NAME|", &st) == -1) {
+        mkdir("|TMP_DIRECTORY_NAME|", 0700);
     }
-    sprintf(file_name, "/tmp/|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
+    sprintf(file_name, "|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
-    host_to_node_sync_file("/tmp/|TMP_DIRECTORY_NAME|");
+    host_to_node_sync_file("|TMP_DIRECTORY_NAME|");
 #endif /* !RP_NODE */
 
 #if RP_HOST

--- a/coupling_components/solver_wrappers/fluent/v2019R2.c
+++ b/coupling_components/solver_wrappers/fluent/v2019R2.c
@@ -1,6 +1,8 @@
 #include "udf.h"
 #include <math.h>
-
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 /* dynamic memory allocation for 1D and 2D arrays */
 #define DECLARE_MEMORY(name, type) type *name = NULL
@@ -498,6 +500,11 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     sprintf(file_name, "nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
 #else
+    struct stat st = {0};
+
+    if (stat("/tmp/|TMP_DIRECTORY_NAME|", &st) == -1) {
+        mkdir("/tmp/|TMP_DIRECTORY_NAME|", 0700);
+    }
     sprintf(file_name, "/tmp/|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
     host_to_node_sync_file("/tmp/|TMP_DIRECTORY_NAME|");
@@ -555,4 +562,3 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 
     if (myid == 0) {printf("\nFinished UDF move_nodes.\n"); fflush(stdout);}
 }
-

--- a/coupling_components/solver_wrappers/fluent/v2019R2.c
+++ b/coupling_components/solver_wrappers/fluent/v2019R2.c
@@ -560,5 +560,9 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     RELEASE_MEMORY(ids);
 #endif /* !RP_HOST */
 
+#if RP_NODE
+    remove(file_name);
+#endif /* RP_NODE */
+
     if (myid == 0) {printf("\nFinished UDF move_nodes.\n"); fflush(stdout);}
 }

--- a/coupling_components/solver_wrappers/fluent/v2019R2.c
+++ b/coupling_components/solver_wrappers/fluent/v2019R2.c
@@ -502,12 +502,12 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #else
     struct stat st = {0};
 
-    if (stat("/tmp/|TMP_DIRECTORY_NAME|", &st) == -1) {
-        mkdir("/tmp/|TMP_DIRECTORY_NAME|", 0700);
+    if (stat("|TMP_DIRECTORY_NAME|", &st) == -1) {
+        mkdir("|TMP_DIRECTORY_NAME|", 0700);
     }
-    sprintf(file_name, "/tmp/|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
+    sprintf(file_name, "|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
-    host_to_node_sync_file("/tmp/|TMP_DIRECTORY_NAME|");
+    host_to_node_sync_file("|TMP_DIRECTORY_NAME|");
 #endif /* !RP_NODE */
 
 #if RP_HOST

--- a/coupling_components/solver_wrappers/fluent/v2019R3.c
+++ b/coupling_components/solver_wrappers/fluent/v2019R3.c
@@ -1,6 +1,8 @@
 #include "udf.h"
 #include <math.h>
-
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 /* dynamic memory allocation for 1D and 2D arrays */
 #define DECLARE_MEMORY(name, type) type *name = NULL
@@ -498,6 +500,11 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     sprintf(file_name, "nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
 #else
+    struct stat st = {0};
+
+    if (stat("/tmp/|TMP_DIRECTORY_NAME|", &st) == -1) {
+        mkdir("/tmp/|TMP_DIRECTORY_NAME|", 0700);
+    }
     sprintf(file_name, "/tmp/|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
     host_to_node_sync_file("/tmp/|TMP_DIRECTORY_NAME|");
@@ -555,4 +562,3 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 
     if (myid == 0) {printf("\nFinished UDF move_nodes.\n"); fflush(stdout);}
 }
-

--- a/coupling_components/solver_wrappers/fluent/v2019R3.c
+++ b/coupling_components/solver_wrappers/fluent/v2019R3.c
@@ -560,5 +560,9 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     RELEASE_MEMORY(ids);
 #endif /* !RP_HOST */
 
+#if RP_NODE
+    remove(file_name);
+#endif /* RP_NODE */
+
     if (myid == 0) {printf("\nFinished UDF move_nodes.\n"); fflush(stdout);}
 }

--- a/coupling_components/solver_wrappers/fluent/v2019R3.c
+++ b/coupling_components/solver_wrappers/fluent/v2019R3.c
@@ -502,12 +502,12 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #else
     struct stat st = {0};
 
-    if (stat("/tmp/|TMP_DIRECTORY_NAME|", &st) == -1) {
-        mkdir("/tmp/|TMP_DIRECTORY_NAME|", 0700);
+    if (stat("|TMP_DIRECTORY_NAME|", &st) == -1) {
+        mkdir("|TMP_DIRECTORY_NAME|", 0700);
     }
-    sprintf(file_name, "/tmp/|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
+    sprintf(file_name, "|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
-    host_to_node_sync_file("/tmp/|TMP_DIRECTORY_NAME|");
+    host_to_node_sync_file("|TMP_DIRECTORY_NAME|");
 #endif /* !RP_NODE */
 
 #if RP_HOST

--- a/coupling_components/solver_wrappers/fluent/v2020R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2020R1.c
@@ -1,6 +1,8 @@
 #include "udf.h"
 #include <math.h>
-
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 /* dynamic memory allocation for 1D and 2D arrays */
 #define DECLARE_MEMORY(name, type) type *name = NULL
@@ -498,6 +500,11 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     sprintf(file_name, "nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
 #else
+    struct stat st = {0};
+
+    if (stat("/tmp/|TMP_DIRECTORY_NAME|", &st) == -1) {
+        mkdir("/tmp/|TMP_DIRECTORY_NAME|", 0700);
+    }
     sprintf(file_name, "/tmp/|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
     host_to_node_sync_file("/tmp/|TMP_DIRECTORY_NAME|");
@@ -555,4 +562,3 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 
     if (myid == 0) {printf("\nFinished UDF move_nodes.\n"); fflush(stdout);}
 }
-

--- a/coupling_components/solver_wrappers/fluent/v2020R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2020R1.c
@@ -560,5 +560,9 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     RELEASE_MEMORY(ids);
 #endif /* !RP_HOST */
 
+#if RP_NODE
+    remove(file_name);
+#endif /* RP_NODE */
+
     if (myid == 0) {printf("\nFinished UDF move_nodes.\n"); fflush(stdout);}
 }

--- a/coupling_components/solver_wrappers/fluent/v2020R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2020R1.c
@@ -502,12 +502,12 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #else
     struct stat st = {0};
 
-    if (stat("/tmp/|TMP_DIRECTORY_NAME|", &st) == -1) {
-        mkdir("/tmp/|TMP_DIRECTORY_NAME|", 0700);
+    if (stat("|TMP_DIRECTORY_NAME|", &st) == -1) {
+        mkdir("|TMP_DIRECTORY_NAME|", 0700);
     }
-    sprintf(file_name, "/tmp/|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
+    sprintf(file_name, "|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
-    host_to_node_sync_file("/tmp/|TMP_DIRECTORY_NAME|");
+    host_to_node_sync_file("|TMP_DIRECTORY_NAME|");
 #endif /* !RP_NODE */
 
 #if RP_HOST

--- a/coupling_components/solver_wrappers/fluent/v2021R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2021R1.c
@@ -483,7 +483,6 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     int i, d, n, node_number;
     DECLARE_MEMORY_N(coords, real, ND_ND);
     DECLARE_MEMORY(ids, int);
-    FILE *file = NULL;
 #endif /* !RP_HOST */
 
 #if !RP_NODE
@@ -495,6 +494,7 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     host_to_node_int_1(timestep);
 
 #if !RP_NODE
+    FILE *file = NULL;
     sprintf(file_name, "nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
 

--- a/coupling_components/solver_wrappers/fluent/v2021R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2021R1.c
@@ -560,5 +560,9 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     RELEASE_MEMORY(ids);
 #endif /* !RP_HOST */
 
+#if RP_NODE
+    remove(file_name);
+#endif /* RP_NODE */
+
     if (myid == 0) {printf("\nFinished UDF move_nodes.\n"); fflush(stdout);}
 }

--- a/coupling_components/solver_wrappers/fluent/v2021R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2021R1.c
@@ -497,17 +497,7 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #if !RP_NODE
     sprintf(file_name, "nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
-#else
-    sprintf(file_name, "/tmp/|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
-            timestep, thread_id);
-    host_to_node_sync_file("/tmp/|TMP_DIRECTORY_NAME|");
-#endif /* !RP_NODE */
 
-#if RP_HOST
-    host_to_node_sync_file(file_name);
-#endif /* RP_HOST */
-
-#if !RP_HOST
     if (NULLP(file = fopen(file_name, "r"))) {
         Error("\nUDF-error: Unable to open %s for reading\n", file_name);
         exit(1);
@@ -526,7 +516,9 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     }
 
     fclose(file);
+#endif /* !RP_NODE */
 
+#if !RP_HOST
     begin_f_loop(face, face_thread) {
         f_node_loop(face, face_thread, node_number) {
             node = F_NODE(face, face_thread, node_number);
@@ -555,4 +547,3 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 
     if (myid == 0) {printf("\nFinished UDF move_nodes.\n"); fflush(stdout);}
 }
-

--- a/coupling_components/solver_wrappers/fluent/v2021R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2021R1.c
@@ -502,12 +502,12 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #else
     struct stat st = {0};
 
-    if (stat("/tmp/|TMP_DIRECTORY_NAME|", &st) == -1) {
-        mkdir("/tmp/|TMP_DIRECTORY_NAME|", 0700);
+    if (stat("|TMP_DIRECTORY_NAME|", &st) == -1) {
+        mkdir("|TMP_DIRECTORY_NAME|", 0700);
     }
-    sprintf(file_name, "/tmp/|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
+    sprintf(file_name, "|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
-    host_to_node_sync_file("/tmp/|TMP_DIRECTORY_NAME|");
+    host_to_node_sync_file("|TMP_DIRECTORY_NAME|");
 #endif /* !RP_NODE */
 
 #if RP_HOST

--- a/coupling_components/solver_wrappers/fluent/v2021R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2021R1.c
@@ -492,9 +492,12 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     host_to_node_int_1(iteration);
     host_to_node_int_1(timestep);
 
-#if !RP_NODE
+#if PARALLEL
     DECLARE_MEMORY_N(coords, real, ND_ND);
     DECLARE_MEMORY(ids, int);
+#endif
+
+#if !RP_NODE
     FILE *file = NULL;
 
     sprintf(file_name, "nodes_update_timestep%i_thread%i.dat",

--- a/coupling_components/solver_wrappers/fluent/v2021R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2021R1.c
@@ -480,6 +480,7 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #if !RP_HOST
     face_t face;
     Node *node;
+    int node_number;
 #endif /* !RP_HOST */
 
 #if !RP_NODE
@@ -491,7 +492,7 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     host_to_node_int_1(timestep);
 
 #if !RP_NODE
-    int i, d, n, node_number;
+    int i, d, n;
     DECLARE_MEMORY_N(coords, real, ND_ND);
     DECLARE_MEMORY(ids, int);
     FILE *file = NULL;

--- a/coupling_components/solver_wrappers/fluent/v2021R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2021R1.c
@@ -480,9 +480,6 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #if !RP_HOST
     face_t face;
     Node *node;
-    int i, d, n, node_number;
-    DECLARE_MEMORY_N(coords, real, ND_ND);
-    DECLARE_MEMORY(ids, int);
 #endif /* !RP_HOST */
 
 #if !RP_NODE
@@ -494,7 +491,11 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     host_to_node_int_1(timestep);
 
 #if !RP_NODE
+    int i, d, n, node_number;
+    DECLARE_MEMORY_N(coords, real, ND_ND);
+    DECLARE_MEMORY(ids, int);
     FILE *file = NULL;
+
     sprintf(file_name, "nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
 

--- a/coupling_components/solver_wrappers/fluent/v2021R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2021R1.c
@@ -476,6 +476,7 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     char file_name[256];
     Thread *face_thread = DT_THREAD(dynamic_thread);
     int thread_id = THREAD_ID(face_thread);
+    int i, d, n;
 
 #if !RP_HOST
     face_t face;
@@ -492,7 +493,6 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     host_to_node_int_1(timestep);
 
 #if !RP_NODE
-    int i, d, n;
     DECLARE_MEMORY_N(coords, real, ND_ND);
     DECLARE_MEMORY(ids, int);
     FILE *file = NULL;

--- a/coupling_components/solver_wrappers/fluent/v2021R2.c
+++ b/coupling_components/solver_wrappers/fluent/v2021R2.c
@@ -1,6 +1,8 @@
 #include "udf.h"
 #include <math.h>
-
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 /* dynamic memory allocation for 1D and 2D arrays */
 #define DECLARE_MEMORY(name, type) type *name = NULL
@@ -498,6 +500,11 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     sprintf(file_name, "nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
 #else
+    struct stat st = {0};
+
+    if (stat("/tmp/|TMP_DIRECTORY_NAME|", &st) == -1) {
+        mkdir("/tmp/|TMP_DIRECTORY_NAME|", 0700);
+    }
     sprintf(file_name, "/tmp/|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
     host_to_node_sync_file("/tmp/|TMP_DIRECTORY_NAME|");
@@ -555,4 +562,3 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 
     if (myid == 0) {printf("\nFinished UDF move_nodes.\n"); fflush(stdout);}
 }
-

--- a/coupling_components/solver_wrappers/fluent/v2021R2.c
+++ b/coupling_components/solver_wrappers/fluent/v2021R2.c
@@ -560,5 +560,9 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     RELEASE_MEMORY(ids);
 #endif /* !RP_HOST */
 
+#if RP_NODE
+    remove(file_name);
+#endif /* RP_NODE */
+
     if (myid == 0) {printf("\nFinished UDF move_nodes.\n"); fflush(stdout);}
 }

--- a/coupling_components/solver_wrappers/fluent/v2021R2.c
+++ b/coupling_components/solver_wrappers/fluent/v2021R2.c
@@ -502,12 +502,12 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #else
     struct stat st = {0};
 
-    if (stat("/tmp/|TMP_DIRECTORY_NAME|", &st) == -1) {
-        mkdir("/tmp/|TMP_DIRECTORY_NAME|", 0700);
+    if (stat("|TMP_DIRECTORY_NAME|", &st) == -1) {
+        mkdir("|TMP_DIRECTORY_NAME|", 0700);
     }
-    sprintf(file_name, "/tmp/|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
+    sprintf(file_name, "|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
-    host_to_node_sync_file("/tmp/|TMP_DIRECTORY_NAME|");
+    host_to_node_sync_file("|TMP_DIRECTORY_NAME|");
 #endif /* !RP_NODE */
 
 #if RP_HOST

--- a/solver_modules.py
+++ b/solver_modules.py
@@ -41,9 +41,8 @@ solver_load_cmd_dict = {
     },
     'breniac': {
         'fluent.v2021R1': 'module load FLUENT/2021R1 && export ANSYSLI_SERVERS=2325@ir03lic1.ugent.be '
-                          '&& export ANSYSLMD_LICENSE_FILE=1055@ir03lic1.ugent.be '
-                          '&& cat $PBS_NODEFILE | sed -e "s/\\.$CLUSTER_NAME.*$//" > fluent.hosts',
-        'abaqus.v614': 'module load intel/2018a && module load ABAQUS/6.14.1-linux-x86_64 && unset SLURM_GITDS '
+                          '&& export ANSYSLMD_LICENSE_FILE=1055@ir03lic1.ugent.be && cat $PBS_NODEFILE > fluent.hosts',
+        'abaqus.v614': 'module load intel/2018a && module load ABAQUS/6.14.1-linux-x86_64 && unset SLURM_GTIDS '
                        '&& export LM_LICENSE_FILE=@ir03lic1.ugent.be:@bump.ugent.be'
     }
 }

--- a/solver_modules.py
+++ b/solver_modules.py
@@ -38,6 +38,13 @@ solver_load_cmd_dict = {
         'abaqus.v614': 'ml intel/2018a && ml ABAQUS/6.14.1-linux-x86_64 && unset SLURM_GTIDS && export LM_LICENSE_FILE='
                        '@ir03lic1.ugent.be:@bump.ugent.be',
         'kratos.structural_mechanics_application.v60': 'ml Kratos/6.0-foss-2018a-Python-3.6.4',
+    },
+    'breniac': {
+        'fluent.v2021R1': 'module load FLUENT/2021R1 && export ANSYSLI_SERVERS=2325@ir03lic1.ugent.be '
+                          '&& export ANSYSLMD_LICENSE_FILE=1055@ir03lic1.ugent.be '
+                          '&& cat $PBS_NODEFILE | sed -e "s/\\.$CLUSTER_NAME.*$//" > fluent.hosts',
+        'abaqus.v614': 'module load intel/2018a && module load ABAQUS/6.14.1-linux-x86_64 && unset SLURM_GITDS '
+                       '&& export LM_LICENSE_FILE=@ir03lic1.ugent.be:@bump.ugent.be'
     }
 }
 

--- a/solver_modules.py
+++ b/solver_modules.py
@@ -5,7 +5,7 @@ uses the environment variables in all the spawned processes, used for executing 
 in the various stages of the simulation.
 """
 
-machine_name = 'breniac'
+machine_name = 'ugent_cluster_CO7'
 
 solver_load_cmd_dict = {
     'ugent_cluster_SL6.3': {

--- a/solver_modules.py
+++ b/solver_modules.py
@@ -5,7 +5,7 @@ uses the environment variables in all the spawned processes, used for executing 
 in the various stages of the simulation.
 """
 
-machine_name = 'ugent_cluster_CO7'
+machine_name = 'breniac'
 
 solver_load_cmd_dict = {
     'ugent_cluster_SL6.3': {
@@ -44,7 +44,7 @@ solver_load_cmd_dict = {
                           '&& export ANSYSLMD_LICENSE_FILE=1055@ir03lic1.ugent.be && cat $PBS_NODEFILE > fluent.hosts',
         'abaqus.v614': 'module load intel/2018a && module load ABAQUS/6.14.1-linux-x86_64 && unset SLURM_GTIDS '
                        '&& export LM_LICENSE_FILE=@ir03lic1.ugent.be:@bump.ugent.be '
-                       '&& export ANSYSLI_SERVERS=2325@ir03lic1.ugent.be'
+                       '&& export INTEL_LICENSE_FILE=28518@157.193.126.6'
     }
 }
 

--- a/solver_modules.py
+++ b/solver_modules.py
@@ -43,8 +43,8 @@ solver_load_cmd_dict = {
         'fluent.v2021R1': 'module load FLUENT/2021R1 && export ANSYSLI_SERVERS=2325@ir03lic1.ugent.be '
                           '&& export ANSYSLMD_LICENSE_FILE=1055@ir03lic1.ugent.be && cat $PBS_NODEFILE > fluent.hosts',
         'abaqus.v614': 'module load intel/2018a && module load ABAQUS/6.14.1-linux-x86_64 && unset SLURM_GTIDS '
-                       '&& export LM_LICENSE_FILE=@ir03lic1.ugent.be:@bump.ugent.be '
-                       '&& export INTEL_LICENSE_FILE=28518@157.193.126.6'
+                       '&& export LM_LICENSE_FILE=@ir03lic1.ugent.be:@bump.ugent.be'
+                       '&& export INTEL_LICENSE_FILE=/apps/gent/licenses/intel/license.lic'
     }
 }
 

--- a/solver_modules.py
+++ b/solver_modules.py
@@ -43,7 +43,8 @@ solver_load_cmd_dict = {
         'fluent.v2021R1': 'module load FLUENT/2021R1 && export ANSYSLI_SERVERS=2325@ir03lic1.ugent.be '
                           '&& export ANSYSLMD_LICENSE_FILE=1055@ir03lic1.ugent.be && cat $PBS_NODEFILE > fluent.hosts',
         'abaqus.v614': 'module load intel/2018a && module load ABAQUS/6.14.1-linux-x86_64 && unset SLURM_GTIDS '
-                       '&& export LM_LICENSE_FILE=@ir03lic1.ugent.be:@bump.ugent.be'
+                       '&& export LM_LICENSE_FILE=@ir03lic1.ugent.be:@bump.ugent.be '
+                       '&& export ANSYSLI_SERVERS=2325@ir03lic1.ugent.be'
     }
 }
 


### PR DESCRIPTION
**Description** The Fluent wrapper has been adjusted to work multi-node. For this a hostfile is required, which needs to be located in the `working_directory`. Its name can be provided as a str via the optional parameter `hostname`. For single-node jobs it does not need to be provided. The `solver_modules.py` file now includes the commands to run on BrENIAC Tier-1 machines. To run CoCoNuT the module SciPy-bundle/2019.10-foss-2019b-Python-3.7.4 can be used. The module SciPy-bundle/2019.10-intel-2019b-Python-3.7.4 conflicts with the Abaqus solver-wrapper, hindering the compilation of `GetOutput.cpp`. Now the code also checks for the value of the `$TMPDIR` environment variable, as requested in issue #163. If it is unset, `/tmp` will still be used. The files put in this temporary folder for inter-node communications are now deleted after they're not needed anymore, in order not to fill up the storage. 

**Users' experience affected?** No.

**Other parts of the code affected?** If the parameter `hostfile` is provided, than the Fluent wrapper won't replace `cores` with the maximum number of cores (which it does in case this parameter being set an incorrect value), as it can only see the cores of the host machine.

**Tests** I ran a tube vibration case on BrENIAC. The Fluent unittest have been ran as well on our local cluster and they still work correctly. The following examples have been run as well: TestBreakingDamFluent2DAbaqus2D, TestTubeFluent2DTubeStructure, TestTubeFluent3DAbaqus2D, TestTurekFluent2DAbaqus2D, TestTurekFluent2DAbaqus2DSteady.

**Related issues** Closes #146, closes #163.

**Checklist**
- [x] Style guidelines
- [x] Self-review of code performed
- [x] Code has been commented (particularly in hard-to-understand areas)
- [x] Documentation was updated correspondingly
- [x] New and existing unit tests pass locally with changes
