### PR TITLE
Remove previous time step instead of current to avoid race condition

### DIFF
--- a/coupling_components/solver_wrappers/abaqus/abaqus.py
+++ b/coupling_components/solver_wrappers/abaqus/abaqus.py
@@ -40,7 +40,7 @@ class SolverWrapperAbaqus(Component):
         self.vault_suffixes = ['023', 'com', 'dat', 'mdl', 'msg', 'odb', 'prt', 'res', 'sim', 'stt']
         self.path_src = os.path.realpath(os.path.dirname(__file__))
         self.logfile = 'abaqus.log'
-        self.tmp_dir = os.environ.get('TMPDIR', '/tmp') # dir for host-node communication
+        self.tmp_dir = os.environ.get('TMPDIR', '/tmp')
         self.tmp_dir_unique = os.path.join(self.tmp_dir, f'coconut_{getuser()}_{os.getpid()}_abaqus')
 
         self.cores = self.settings['cores']  # number of CPUs Abaqus has to use

--- a/coupling_components/solver_wrappers/fluent/fluent.py
+++ b/coupling_components/solver_wrappers/fluent/fluent.py
@@ -41,7 +41,7 @@ class SolverWrapperFluent(Component):
         self.remove_all_messages()
         self.backup_fluent_log()
         self.dir_src = os.path.realpath(os.path.dirname(__file__))
-        self.tmp_dir = os.environ.get('TMPDIR', '/tmp') # dir for host-node communication
+        self.tmp_dir = os.environ.get('TMPDIR', '/tmp')  # dir for host-node communication
         self.tmp_dir_unique = os.path.join(self.tmp_dir, f'coconut_{getuser()}_{os.getpid()}_fluent')
         self.cores = self.settings['cores']
         self.hostfile = self.settings.get('hostfile')
@@ -388,7 +388,7 @@ class SolverWrapperFluent(Component):
 
     def finalize(self):
         super().finalize()
-        shutil.rmtree(join('/tmp', self.tmp_dir_unique), ignore_errors=True)
+        shutil.rmtree(self.tmp_dir_unique, ignore_errors=True)
         self.send_message('stop')
         self.wait_message('stop_ready')
         self.fluent_process.wait()

--- a/coupling_components/solver_wrappers/fluent/v2019R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2019R1.c
@@ -499,6 +499,7 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #if !RP_NODE
     sprintf(file_name, "nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
+    host_to_node_sync_file(file_name); /* send */
 #else
     struct stat st = {0};
 
@@ -507,12 +508,8 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     }
     sprintf(file_name, "|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
-    host_to_node_sync_file("|TMP_DIRECTORY_NAME|");
+    host_to_node_sync_file("|TMP_DIRECTORY_NAME|");  /* receive */
 #endif /* !RP_NODE */
-
-#if RP_HOST
-    host_to_node_sync_file(file_name);
-#endif /* RP_HOST */
 
 #if !RP_HOST
     if (NULLP(file = fopen(file_name, "r"))) {
@@ -551,18 +548,18 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
                         exit(1);
                     }
                 }
-
             }
         }
     } end_f_loop(face, face_thread);
 
     RELEASE_MEMORY_N(coords, ND_ND);
     RELEASE_MEMORY(ids);
-#endif /* !RP_HOST */
 
-#if RP_NODE
-    remove(file_name);
-#endif /* RP_NODE */
+    if (myid == 0) {
+        sprintf(file_name, "|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
+                timestep-1, thread_id);
+        remove(file_name);}
+#endif /* !RP_HOST */
 
     if (myid == 0) {printf("\nFinished UDF move_nodes.\n"); fflush(stdout);}
 }

--- a/coupling_components/solver_wrappers/fluent/v2019R2.c
+++ b/coupling_components/solver_wrappers/fluent/v2019R2.c
@@ -499,6 +499,7 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #if !RP_NODE
     sprintf(file_name, "nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
+    host_to_node_sync_file(file_name); /* send */
 #else
     struct stat st = {0};
 
@@ -507,12 +508,8 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     }
     sprintf(file_name, "|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
-    host_to_node_sync_file("|TMP_DIRECTORY_NAME|");
+    host_to_node_sync_file("|TMP_DIRECTORY_NAME|");  /* receive */
 #endif /* !RP_NODE */
-
-#if RP_HOST
-    host_to_node_sync_file(file_name);
-#endif /* RP_HOST */
 
 #if !RP_HOST
     if (NULLP(file = fopen(file_name, "r"))) {
@@ -551,18 +548,18 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
                         exit(1);
                     }
                 }
-
             }
         }
     } end_f_loop(face, face_thread);
 
     RELEASE_MEMORY_N(coords, ND_ND);
     RELEASE_MEMORY(ids);
-#endif /* !RP_HOST */
 
-#if RP_NODE
-    remove(file_name);
-#endif /* RP_NODE */
+    if (myid == 0) {
+        sprintf(file_name, "|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
+                timestep-1, thread_id);
+        remove(file_name);}
+#endif /* !RP_HOST */
 
     if (myid == 0) {printf("\nFinished UDF move_nodes.\n"); fflush(stdout);}
 }

--- a/coupling_components/solver_wrappers/fluent/v2019R3.c
+++ b/coupling_components/solver_wrappers/fluent/v2019R3.c
@@ -499,6 +499,7 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #if !RP_NODE
     sprintf(file_name, "nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
+    host_to_node_sync_file(file_name); /* send */
 #else
     struct stat st = {0};
 
@@ -507,12 +508,8 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     }
     sprintf(file_name, "|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
-    host_to_node_sync_file("|TMP_DIRECTORY_NAME|");
+    host_to_node_sync_file("|TMP_DIRECTORY_NAME|");  /* receive */
 #endif /* !RP_NODE */
-
-#if RP_HOST
-    host_to_node_sync_file(file_name);
-#endif /* RP_HOST */
 
 #if !RP_HOST
     if (NULLP(file = fopen(file_name, "r"))) {
@@ -551,18 +548,18 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
                         exit(1);
                     }
                 }
-
             }
         }
     } end_f_loop(face, face_thread);
 
     RELEASE_MEMORY_N(coords, ND_ND);
     RELEASE_MEMORY(ids);
-#endif /* !RP_HOST */
 
-#if RP_NODE
-    remove(file_name);
-#endif /* RP_NODE */
+    if (myid == 0) {
+        sprintf(file_name, "|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
+                timestep-1, thread_id);
+        remove(file_name);}
+#endif /* !RP_HOST */
 
     if (myid == 0) {printf("\nFinished UDF move_nodes.\n"); fflush(stdout);}
 }

--- a/coupling_components/solver_wrappers/fluent/v2020R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2020R1.c
@@ -499,6 +499,7 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #if !RP_NODE
     sprintf(file_name, "nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
+    host_to_node_sync_file(file_name); /* send */
 #else
     struct stat st = {0};
 
@@ -507,12 +508,8 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     }
     sprintf(file_name, "|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
-    host_to_node_sync_file("|TMP_DIRECTORY_NAME|");
+    host_to_node_sync_file("|TMP_DIRECTORY_NAME|");  /* receive */
 #endif /* !RP_NODE */
-
-#if RP_HOST
-    host_to_node_sync_file(file_name);
-#endif /* RP_HOST */
 
 #if !RP_HOST
     if (NULLP(file = fopen(file_name, "r"))) {
@@ -551,18 +548,18 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
                         exit(1);
                     }
                 }
-
             }
         }
     } end_f_loop(face, face_thread);
 
     RELEASE_MEMORY_N(coords, ND_ND);
     RELEASE_MEMORY(ids);
-#endif /* !RP_HOST */
 
-#if RP_NODE
-    remove(file_name);
-#endif /* RP_NODE */
+    if (myid == 0) {
+        sprintf(file_name, "|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
+                timestep-1, thread_id);
+        remove(file_name);}
+#endif /* !RP_HOST */
 
     if (myid == 0) {printf("\nFinished UDF move_nodes.\n"); fflush(stdout);}
 }

--- a/coupling_components/solver_wrappers/fluent/v2021R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2021R1.c
@@ -499,6 +499,7 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #if !RP_NODE
     sprintf(file_name, "nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
+    host_to_node_sync_file(file_name); /* send */
 #else
     struct stat st = {0};
 
@@ -507,12 +508,8 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     }
     sprintf(file_name, "|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
-    host_to_node_sync_file("|TMP_DIRECTORY_NAME|");
+    host_to_node_sync_file("|TMP_DIRECTORY_NAME|");  /* receive */
 #endif /* !RP_NODE */
-
-#if RP_HOST
-    host_to_node_sync_file(file_name);
-#endif /* RP_HOST */
 
 #if !RP_HOST
     if (NULLP(file = fopen(file_name, "r"))) {
@@ -551,18 +548,18 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
                         exit(1);
                     }
                 }
-
             }
         }
     } end_f_loop(face, face_thread);
 
     RELEASE_MEMORY_N(coords, ND_ND);
     RELEASE_MEMORY(ids);
-#endif /* !RP_HOST */
 
-#if RP_NODE
-    remove(file_name);
-#endif /* RP_NODE */
+    if (myid == 0) {
+        sprintf(file_name, "|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
+                timestep-1, thread_id);
+        remove(file_name);}
+#endif /* !RP_HOST */
 
     if (myid == 0) {printf("\nFinished UDF move_nodes.\n"); fflush(stdout);}
 }

--- a/coupling_components/solver_wrappers/fluent/v2021R2.c
+++ b/coupling_components/solver_wrappers/fluent/v2021R2.c
@@ -499,6 +499,7 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #if !RP_NODE
     sprintf(file_name, "nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
+    host_to_node_sync_file(file_name); /* send */
 #else
     struct stat st = {0};
 
@@ -507,12 +508,8 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
     }
     sprintf(file_name, "|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
             timestep, thread_id);
-    host_to_node_sync_file("|TMP_DIRECTORY_NAME|");
+    host_to_node_sync_file("|TMP_DIRECTORY_NAME|");  /* receive */
 #endif /* !RP_NODE */
-
-#if RP_HOST
-    host_to_node_sync_file(file_name);
-#endif /* RP_HOST */
 
 #if !RP_HOST
     if (NULLP(file = fopen(file_name, "r"))) {
@@ -551,18 +548,18 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
                         exit(1);
                     }
                 }
-
             }
         }
     } end_f_loop(face, face_thread);
 
     RELEASE_MEMORY_N(coords, ND_ND);
     RELEASE_MEMORY(ids);
-#endif /* !RP_HOST */
 
-#if RP_NODE
-    remove(file_name);
-#endif /* RP_NODE */
+    if (myid == 0) {
+        sprintf(file_name, "|TMP_DIRECTORY_NAME|/nodes_update_timestep%i_thread%i.dat",
+                timestep-1, thread_id);
+        remove(file_name);}
+#endif /* !RP_HOST */
 
     if (myid == 0) {printf("\nFinished UDF move_nodes.\n"); fflush(stdout);}
 }


### PR DESCRIPTION
**Description** The files with the node displacement in the $TMPDIR or /tmp folder are now removed one time step later, such that a race condition is avoided, where one process already removes the file before another one can read it. Furthermore the UDF has been restructured a little bit to make it more readable.

**Users' experience affected?** It's a bugfix.

**Other parts of the code affected?** No.

**Tests** All unittests have been run locally, both with the default /tmp folder as a custom $TMPDIR. Also some examples using Fluent were run (both with `evaluate_examples.py` and the full 100 time steps). 

**Related issues** Fixes #164 

**Checklist**
- [x] Style guidelines
- [x] Self-review of code performed
- [x] Code has been commented (particularly in hard-to-understand areas)
- [x] Documentation was updated correspondingly
- [x] New and existing unit tests pass locally with changes
