### PR TITLE
Fluent log file now also created when fluent_gui = True

### DIFF
--- a/coupling_components/solver_wrappers/fluent/fluent.py
+++ b/coupling_components/solver_wrappers/fluent/fluent.py
@@ -127,13 +127,14 @@ class SolverWrapperFluent(Component):
         log = join(self.dir_cfd, 'fluent.log')
         cmd1 = f'fluent -r{self.version_bis} {self.dimensions}ddp '
         cmd2 = f'-t{self.cores} -i {journal}'
+        cmd3 = f' >> {log} 2>&1'
 
         if self.hostfile is not None:
             cmd1 += f' -cnf={self.hostfile} -ssh '
         if self.settings['fluent_gui']:
-            cmd = cmd1 + cmd2
+            cmd = cmd1 + cmd2 + cmd3
         else:
-            cmd = cmd1 + '-gu ' + cmd2 + f' >> {log} 2>&1'  # TODO: does log work well?
+            cmd = cmd1 + '-gu ' + cmd2 + cmd3 # TODO: does log work well?
             # cmd = cmd1 + '-gu ' + cmd2 + f' 2> >(tee -a {log}) 1>> {log}'  # TODO: specify what this option does?
         self.fluent_process = subprocess.Popen(cmd, executable='/bin/bash',
                                                shell=True, cwd=self.dir_cfd, env=self.env)


### PR DESCRIPTION
**Description** Bug fix. The Fluent GUI can now be used.
**Users' experience affected?** The Fluent GUI can now be used.

**Other parts of the code affected?**  No.

**Tests** tube_fluent2d_abaqus2d for different versions, fluent unit test "test_v2019R3.py", tube_fluent3d_abaqus2d (2019R3)

**Related issues** Closes #158

**Checklist**
- [X ] Style guidelines
    1. CoCoNuT follows [the PEP8 style guide](https://www.python.org/dev/peps/pep-0008/).
    2. Comments should be lowercase.
    3. Errors should start with capitals, preferably without punctuation unless it's multiple sentences.
    4. Strings should use single quotes whenever possible.	
- [X ] Self-review of code performed
- [ ] Code has been commented (particularly in hard-to-understand areas)
- [ ] Documentation was updated correspondingly
- [ X] New and existing unit tests pass locally with changes
