### PR TITLE
update solver modules of HPC Tier 2

### DIFF
--- a/solver_modules.py
+++ b/solver_modules.py
@@ -47,8 +47,6 @@ solver_load_cmd_dict = {
         'fluent.v2022R1': 'ml FLUENT/2022R1 && ml intel/2021a && unset SLURM_GTIDS '
                           '&& export ANSYSLI_SERVERS=2325@ir03lic1.ugent.be '
                           '&& export ANSYSLMD_LICENSE_FILE=1055@ir03lic1.ugent.be && cat $PBS_NODEFILE > fluent.hosts',
-        'abaqus.v2021': 'ml intel/2020a && ml ABAQUS/2021-hotfix-2132 '
-                        '&& export LM_LICENSE_FILE=@ir03lic1.ugent.be:@bump.ugent.be',
         'abaqus.v2022': 'ml intel/2020a && ml ABAQUS/2022 && export LM_LICENSE_FILE=@ir03lic1.ugent.be:@bump.ugent.be'
     },
     'breniac': {

--- a/solver_modules.py
+++ b/solver_modules.py
@@ -41,11 +41,13 @@ solver_load_cmd_dict = {
         'openfoam.v8': 'ml OpenFOAM/8-foss-2020b && source $FOAM_BASH'
     },
     'ugent_hpc': {
-        'fluent.v2019R3': 'ml FLUENT/2019R3',
-        'fluent.v2021R2': 'ml FLUENT/2021R2',
-        'fluent.v2022R1': 'ml FLUENT/2022R1',
-        'abaqus.v614': 'ml intel/2018a && ml ABAQUS/6.14.1-linux-x86_64 && unset SLURM_GTIDS && export LM_LICENSE_FILE='
-                       '@ir03lic1.ugent.be:@bump.ugent.be',
+        'fluent.v2021R2': 'ml FLUENT/2021R2 && ml intel/2021a && unset SLURM_GTIDS '
+                          '&& export ANSYSLI_SERVERS=2325@ir03lic1.ugent.be '
+                          '&& export ANSYSLMD_LICENSE_FILE=1055@ir03lic1.ugent.be && cat $PBS_NODEFILE > fluent.hosts',
+        'fluent.v2022R1': 'ml FLUENT/2022R1 && ml intel/2021a && unset SLURM_GTIDS '
+                          '&& export ANSYSLI_SERVERS=2325@ir03lic1.ugent.be '
+                          '&& export ANSYSLMD_LICENSE_FILE=1055@ir03lic1.ugent.be && cat $PBS_NODEFILE > fluent.hosts',
+        'abaqus.v2022': 'ml intel/2020a && ml ABAQUS/2022 && export LM_LICENSE_FILE=@ir03lic1.ugent.be:@bump.ugent.be',
         'kratos_structure.v60': 'ml Kratos/6.0-foss-2018a-Python-3.6.4'
     },
     'breniac': {

--- a/solver_modules.py
+++ b/solver_modules.py
@@ -47,6 +47,8 @@ solver_load_cmd_dict = {
         'fluent.v2022R1': 'ml FLUENT/2022R1 && ml intel/2021a && unset SLURM_GTIDS '
                           '&& export ANSYSLI_SERVERS=2325@ir03lic1.ugent.be '
                           '&& export ANSYSLMD_LICENSE_FILE=1055@ir03lic1.ugent.be && cat $PBS_NODEFILE > fluent.hosts',
+        'abaqus.v2021': 'ml intel/2020a && ml ABAQUS/2021-hotfix-2132 '
+                        '&& export LM_LICENSE_FILE=@ir03lic1.ugent.be:@bump.ugent.be',
         'abaqus.v2022': 'ml intel/2020a && ml ABAQUS/2022 && export LM_LICENSE_FILE=@ir03lic1.ugent.be:@bump.ugent.be'
     },
     'breniac': {

--- a/solver_modules.py
+++ b/solver_modules.py
@@ -47,8 +47,7 @@ solver_load_cmd_dict = {
         'fluent.v2022R1': 'ml FLUENT/2022R1 && ml intel/2021a && unset SLURM_GTIDS '
                           '&& export ANSYSLI_SERVERS=2325@ir03lic1.ugent.be '
                           '&& export ANSYSLMD_LICENSE_FILE=1055@ir03lic1.ugent.be && cat $PBS_NODEFILE > fluent.hosts',
-        'abaqus.v2022': 'ml intel/2020a && ml ABAQUS/2022 && export LM_LICENSE_FILE=@ir03lic1.ugent.be:@bump.ugent.be',
-        'kratos_structure.v60': 'ml Kratos/6.0-foss-2018a-Python-3.6.4'
+        'abaqus.v2022': 'ml intel/2020a && ml ABAQUS/2022 && export LM_LICENSE_FILE=@ir03lic1.ugent.be:@bump.ugent.be'
     },
     'breniac': {
         'fluent.v2021R1': 'module load FLUENT/2021R1 && export ANSYSLI_SERVERS=2325@ir03lic1.ugent.be '

--- a/tests/solver_wrappers/fluent/test_v2022R1.py
+++ b/tests/solver_wrappers/fluent/test_v2022R1.py
@@ -8,13 +8,13 @@ version = '2022R1'
 
 
 @unittest.skipUnless(solver_available(f'fluent.v{version}'), f'fluent.v{version} not available')
-class TestSolverWrapperFluent2021R2Tube2D(fluent.TestSolverWrapperFluentTube2D):
+class TestSolverWrapperFluent2022R1Tube2D(fluent.TestSolverWrapperFluentTube2D):
     version = version
     setup_case = True
 
 
 @unittest.skipUnless(solver_available(f'fluent.v{version}'), f'fluent.v{version} not available')
-class TestSolverWrapperFluent2021R2Tube3D(fluent.TestSolverWrapperFluentTube3D):
+class TestSolverWrapperFluent2022R1Tube3D(fluent.TestSolverWrapperFluentTube3D):
     version = version
     setup_case = True
 


### PR DESCRIPTION
**Description** Update of the solver modules for the HPC Tier 2 infrastructure of UGent:
Fluent: removed version 2019R3 as it is not supported by the RHEL 8 operating system of the HPC; added the now necessary intel module, license information and auto-create the hostfile as 'fluent.hosts' (see [parameters](https://pyfsi.github.io/coconut/fluent.html#parameters), required for multi-node jobs).
Abaqus: removed version 6.14 as it is no longer installed; added version 2022.
Kratos: removed since no longer installed on HPC Tier 2.

**Users' experience affected?** The oldest versions of Fluent and Abaqus are now deprecated on the HPC. Kratos no longer available. 
On HPC: request a full node to run Fluent unit tests, otherwise Fluent will be launched with more cores than available to the user. The use of Fluent/2019R3 and Abaqus/2021-hotfix-2132 should be avoided since they are not well supported by the RHEL 8 operating system.

**Other parts of the code affected?** N/A

**Tests** Tested the module combination in a Fluent-only job on the HPC. Unit tests pass on Swalot and Doduo clusters.

**Related issues** N/A

**Checklist**
- [x] Style guidelines
    1. CoCoNuT follows [the PEP8 style guide](https://www.python.org/dev/peps/pep-0008/).
    2. Comments should be lowercase.
    3. Errors should start with capitals, preferably without punctuation unless it's multiple sentences.
    4. Strings should use single quotes whenever possible.	
- [x] Self-review of code performed
- [x] Code has been commented (particularly in hard-to-understand areas)
- [x] Documentation was updated correspondingly
- [x] New and existing unit tests pass locally with changes
