### PR TITLE
Fix processor sync OpenFOAM

### DIFF
--- a/coupling_components/coupled_solvers/iqnism.py
+++ b/coupling_components/coupled_solvers/iqnism.py
@@ -36,7 +36,7 @@ class CoupledSolverIQNISM(CoupledSolver):
                 and 'omega' not in self.settings):
             raise ValueError('A relaxation factor (omega) is required when no surrogate Jacobian is used')
 
-        self.restart_model_surrogate = [False, False]  # indicates if model has to be restarted
+        self.restart_model_surrogate = [False, False]  # indicates if model and/or surrogate has to be restarted
 
     def initialize(self):
         super().initialize()

--- a/coupling_components/solver_wrappers/kratos_structure/kratos_structure.py
+++ b/coupling_components/solver_wrappers/kratos_structure/kratos_structure.py
@@ -66,7 +66,7 @@ class SolverWrapperKratosStructure(SolverWrapper):
         dir_path = os.path.dirname(os.path.realpath(__file__))
         run_script_file = os.path.join(dir_path, f'run_kratos_structural_{self.version}.py')
 
-        self.kratos_process = Popen(f'python3 {run_script_file} {input_file_name} &> log',
+        self.kratos_process = Popen(f'python3 {run_script_file} {input_file_name} &> kratos.log',
                                     shell=True, cwd=self.working_directory, env=self.env)
         self.coco_messages.wait_message('start_ready')
 

--- a/coupling_components/solver_wrappers/openfoam/executeCoconutFunctionObjects.H
+++ b/coupling_components/solver_wrappers/openfoam/executeCoconutFunctionObjects.H
@@ -1,0 +1,7 @@
+forAll(coconutFunctionObjects, i)
+{
+    word functionObject(coconutFunctionObjects[i]);
+    label oi(runTime.functionObjects().findObjectID(functionObject));
+    runTime.functionObjects()[oi].execute();
+    runTime.functionObjects()[oi].write();
+}

--- a/coupling_components/solver_wrappers/openfoam/openfoam.py
+++ b/coupling_components/solver_wrappers/openfoam/openfoam.py
@@ -565,18 +565,21 @@ class SolverWrapperOpenFOAM(SolverWrapper):
         with open(file_name, 'w') as control_dict_file:
             control_dict_file.write(control_dict)
             control_dict_file.write(coconut_start_string + '\n')
-            control_dict_file.write('boundary_names (')
 
-            for boundary_name in self.boundary_names:
-                control_dict_file.write(boundary_name + ' ')
+            control_dict_file.write('boundaryNames (' + ' '.join(self.boundary_names) + ');\n\n')
 
-            control_dict_file.write(');\n\n')
             control_dict_file.write('functions\n{\n')
-
-            control_dict_file.write(self.wall_shear_stress_dict())
+            dct, name = self.wall_shear_stress_dict()
+            control_dict_file.write(dct)
+            function_object_names = [name]
             for boundary_name in self.boundary_names:
-                control_dict_file.write(self.pressure_and_traction_dict(boundary_name))
-            control_dict_file.write('}')
+                dct, name = self.pressure_and_traction_dict(boundary_name)
+                control_dict_file.write(dct)
+                function_object_names.append(name)
+            control_dict_file.write('}\n\n')
+
+            control_dict_file.write('coconutFunctionObjects \n(\n\t' + '\n\t'.join(function_object_names)+'\n);\n')
+
             self.write_footer(file_name)
 
     def wall_shear_stress_dict(self):

--- a/coupling_components/solver_wrappers/openfoam/openfoam.py
+++ b/coupling_components/solver_wrappers/openfoam/openfoam.py
@@ -313,9 +313,8 @@ class SolverWrapperOpenFOAM(SolverWrapper):
                                                         self.cur_timestamp)
                 shutil.rmtree(post_process_time_folder)
 
-        if not (self.timestep % self.write_interval):
-            self.coco_messages.send_message('save')
-            self.coco_messages.wait_message('save_ready')
+        self.coco_messages.send_message('save')
+        self.coco_messages.wait_message('save_ready')
 
         if self.residual_variables is not None:
             self.write_of_residuals()

--- a/coupling_components/solver_wrappers/openfoam/openfoam.py
+++ b/coupling_components/solver_wrappers/openfoam/openfoam.py
@@ -128,7 +128,7 @@ class SolverWrapperOpenFOAM(SolverWrapper):
         # self.settings["boundary_names"]
         self.read_modify_controldict()
 
-        if self.save_restart % self.write_interval:
+        if self.write_interval is not None and self.save_restart % self.write_interval:
             raise RuntimeError(
                 f'self.save_restart (= {self.save_restart}) should be an integer multiple of writeInterval '
                 f'(= {self.write_interval}). Modify the controlDict accordingly.')
@@ -536,7 +536,9 @@ class SolverWrapperOpenFOAM(SolverWrapper):
         file_name = os.path.join(self.working_directory, 'system/controlDict')
         with open(file_name, 'r') as control_dict_file:
             control_dict = control_dict_file.read()
-        self.write_interval = of_io.get_int(input_string=control_dict, keyword='writeInterval')
+        write_control = of_io.get_string(input_string=control_dict, keyword='writeControl')
+        if write_control == 'timeStep':
+            self.write_interval = of_io.get_int(input_string=control_dict, keyword='writeInterval')
         time_format = of_io.get_string(input_string=control_dict, keyword='timeFormat')
         self.write_precision = of_io.get_int(input_string=control_dict, keyword='writePrecision')
 

--- a/coupling_components/solver_wrappers/openfoam/v41.py
+++ b/coupling_components/solver_wrappers/openfoam/v41.py
@@ -38,19 +38,21 @@ class SolverWrapperOpenFOAM41(SolverWrapperOpenFOAM):
         return x0, y0, z0
 
     def wall_shear_stress_dict(self):
-        dct = (f'    {self.wall_shear_stress_variable}\n'
+        name = self.wall_shear_stress_variable
+        dct = (f'    {name}\n'
                f'    {{\n'
                f'        type            {self.wall_shear_stress_variable};\n'
                f'        libs            ("libfieldFunctionObjects.so");\n'
                f'        executeControl  timeStep;\n'
                f'        executeInterval 1;\n'
                f'        writeControl    none;\n'
-               f'        patches         $boundary_names;\n'
+               f'        patches         $boundaryNames;\n'
                f'    }}\n')
-        return dct
+        return dct, name
 
     def pressure_and_traction_dict(self, boundary_name):
-        dct = (f'    coconut_{boundary_name}\n'
+        name = f'coconut_{boundary_name}'
+        dct = (f'    {name}\n'
                f'    {{\n'
                f'        type            surfaceRegion;\n'
                f'        libs            ("libfieldFunctionObjects.so");\n'
@@ -63,4 +65,4 @@ class SolverWrapperOpenFOAM41(SolverWrapperOpenFOAM):
                f'        name            {boundary_name};\n'
                f'        fields          (p {self.wall_shear_stress_variable});\n'
                f'    }}\n')
-        return dct
+        return dct, name

--- a/coupling_components/solver_wrappers/openfoam/v41/coconut_interFoam/coconut_interFoam.C
+++ b/coupling_components/solver_wrappers/openfoam/v41/coconut_interFoam/coconut_interFoam.C
@@ -98,6 +98,8 @@ int main(int argc, char *argv[])
     IOdictionary controlDict(IOobject("controlDict", runTime.system(), mesh, IOobject::MUST_READ,IOobject::NO_WRITE));
     wordList boundary_names (controlDict.lookup("boundary_names"));
 
+    runTime.functionObjects().start();
+
     while (true) // NOT runTime.run()
     {
         usleep(1000); // Expressed in microseconds

--- a/coupling_components/solver_wrappers/openfoam/v41/coconut_interFoam/coconut_interFoam.C
+++ b/coupling_components/solver_wrappers/openfoam/v41/coconut_interFoam/coconut_interFoam.C
@@ -96,17 +96,18 @@ int main(int argc, char *argv[])
     iteration = 0;
 
     IOdictionary controlDict(IOobject("controlDict", runTime.system(), mesh, IOobject::MUST_READ,IOobject::NO_WRITE));
-    wordList boundary_names (controlDict.lookup("boundary_names"));
+    wordList boundaryNames (controlDict.lookup("boundaryNames"));
+    wordList coconutFunctionObjects (controlDict.lookup("coconutFunctionObjects"));
 
-    runTime.functionObjects().start();
-
-    while (true) // NOT runTime.run()
+    while (true)
     {
         usleep(1000); // Expressed in microseconds
 
         if (exists("next.coco"))
         {
             waitForSync("next"); // Keep the sync at the beginning of the block
+
+            runTime.run();
 
             #include "readControls.H"
 
@@ -128,10 +129,10 @@ int main(int argc, char *argv[])
             Info << "Coupling iteration = " << iteration << nl << endl;
 
             // Define movement of the coupling interface
-            forAll(boundary_names, s)
+            forAll(boundaryNames, s)
             {
-                word boundary_name = boundary_names[s];
-                ApplyFSIPointDisplacement(mesh, boundary_name);
+                word boundaryName = boundaryNames[s];
+                ApplyFSIPointDisplacement(mesh, boundaryName);
             }
 
             // --- Pressure-velocity PIMPLE corrector loop
@@ -194,7 +195,7 @@ int main(int argc, char *argv[])
                 << nl << endl;
 
             // Return the coupling interface output
-            runTime.run();
+            #include "executeCoconutFunctionObjects.H"
 
             Info << "Coupling iteration " << iteration << " end" << nl << endl;
         }

--- a/coupling_components/solver_wrappers/openfoam/v41/coconut_pimpleFoam/coconut_pimpleFoam.C
+++ b/coupling_components/solver_wrappers/openfoam/v41/coconut_pimpleFoam/coconut_pimpleFoam.C
@@ -70,17 +70,18 @@ int main(int argc, char *argv[])
     iteration = 0;
 
     IOdictionary controlDict(IOobject("controlDict", runTime.system(), mesh, IOobject::MUST_READ,IOobject::NO_WRITE));
-    wordList boundary_names (controlDict.lookup("boundary_names"));
+    wordList boundaryNames (controlDict.lookup("boundaryNames"));
+    wordList coconutFunctionObjects (controlDict.lookup("coconutFunctionObjects"));
 
-    runTime.functionObjects().start();
-
-    while (true) // NOT runTime.run()
+    while (true)
     {
         usleep(1000); // Expressed in microseconds
 
         if (exists("next.coco"))
         {
             waitForSync("next"); // Keep the sync at the beginning of the block
+
+            runTime.run();
 
             #include "readControls.H"
             #include "CourantNo.H"
@@ -100,10 +101,10 @@ int main(int argc, char *argv[])
             Info << "Coupling iteration = " << iteration << nl << endl;
 
             // Define movement of the coupling interface
-            forAll(boundary_names, s)
+            forAll(boundaryNames, s)
             {
-                word boundary_name = boundary_names[s];
-                ApplyFSIPointDisplacement(mesh, boundary_name);
+                word boundaryName = boundaryNames[s];
+                ApplyFSIPointDisplacement(mesh, boundaryName);
             }
 
             // Calculate the mesh motion and update the mesh
@@ -148,7 +149,7 @@ int main(int argc, char *argv[])
                 << nl << endl;
 
             // Return the coupling interface output
-            runTime.run();
+            #include "executeCoconutFunctionObjects.H"
 
             Info << "Coupling iteration " << iteration << " end" << nl << endl;
         }

--- a/coupling_components/solver_wrappers/openfoam/v41/coconut_pimpleFoam/coconut_pimpleFoam.C
+++ b/coupling_components/solver_wrappers/openfoam/v41/coconut_pimpleFoam/coconut_pimpleFoam.C
@@ -72,6 +72,8 @@ int main(int argc, char *argv[])
     IOdictionary controlDict(IOobject("controlDict", runTime.system(), mesh, IOobject::MUST_READ,IOobject::NO_WRITE));
     wordList boundary_names (controlDict.lookup("boundary_names"));
 
+    runTime.functionObjects().start();
+
     while (true) // NOT runTime.run()
     {
         usleep(1000); // Expressed in microseconds

--- a/coupling_components/solver_wrappers/openfoam/v8.py
+++ b/coupling_components/solver_wrappers/openfoam/v8.py
@@ -38,19 +38,21 @@ class SolverWrapperOpenFOAM8(SolverWrapperOpenFOAM):
         return x0, y0, z0
 
     def wall_shear_stress_dict(self):
-        dct = (f'    {self.wall_shear_stress_variable}\n'
+        name = self.wall_shear_stress_variable
+        dct = (f'    {name}\n'
                f'    {{\n'
                f'        type            {self.wall_shear_stress_variable};\n'
                f'        libs            ("libfieldFunctionObjects.so");\n'
                f'        executeControl  timeStep;\n'
                f'        executeInterval 1;\n'
                f'        writeControl    none;\n'
-               f'        patches         $boundary_names;\n'
+               f'        patches         $boundaryNames;\n'
                f'    }}\n')
-        return dct
+        return dct, name
 
     def pressure_and_traction_dict(self, boundary_name):
-        dct = (f'    coconut_{boundary_name}\n'
+        name = f'coconut_{boundary_name}'
+        dct = (f'    {name}\n'
                f'    {{\n'
                f'        type            surfaceFieldValue;\n'
                f'        libs            ("libfieldFunctionObjects.so");\n'
@@ -63,4 +65,4 @@ class SolverWrapperOpenFOAM8(SolverWrapperOpenFOAM):
                f'        name            {boundary_name};\n'
                f'        fields          (p {self.wall_shear_stress_variable});\n'
                f'    }}\n')
-        return dct
+        return dct, name

--- a/coupling_components/solver_wrappers/openfoam/v8/coconut_cavitatingFoam/coconut_cavitatingFoam.C
+++ b/coupling_components/solver_wrappers/openfoam/v8/coconut_cavitatingFoam/coconut_cavitatingFoam.C
@@ -72,6 +72,8 @@ int main(int argc, char *argv[])
     IOdictionary controlDict(IOobject("controlDict", runTime.system(), mesh, IOobject::MUST_READ,IOobject::NO_WRITE));
     wordList boundary_names (controlDict.lookup("boundary_names"));
 
+    runTime.functionObjects().start();
+
     while (true) // NOT (pimple.run(runTime))
     {
         usleep(1000); // Expressed in microseconds
@@ -110,15 +112,12 @@ int main(int argc, char *argv[])
             // Do any mesh changes
             mesh.update();
 
-            if (mesh.changing())
+            if (mesh.changing() && correctPhi)
             {
                 // Calculate absolute flux from the mapped surface velocity
                 phi = mesh.Sf() & Uf();
 
-                if (correctPhi)
-                {
-                    #include "correctPhi.H"
-                }
+                #include "correctPhi.H"
 
                 // Make the flux relative to the mesh motion
                 fvc::makeRelative(phi, U);

--- a/coupling_components/solver_wrappers/openfoam/v8/coconut_cavitatingFoam/coconut_cavitatingFoam.C
+++ b/coupling_components/solver_wrappers/openfoam/v8/coconut_cavitatingFoam/coconut_cavitatingFoam.C
@@ -70,17 +70,18 @@ int main(int argc, char *argv[])
     iteration = 0;
 
     IOdictionary controlDict(IOobject("controlDict", runTime.system(), mesh, IOobject::MUST_READ,IOobject::NO_WRITE));
-    wordList boundary_names (controlDict.lookup("boundary_names"));
+    wordList boundaryNames (controlDict.lookup("boundaryNames"));
+    wordList coconutFunctionObjects (controlDict.lookup("coconutFunctionObjects"));
 
-    runTime.functionObjects().start();
-
-    while (true) // NOT (pimple.run(runTime))
+    while (true)
     {
         usleep(1000); // Expressed in microseconds
 
         if (exists("next.coco"))
         {
             waitForSync("next"); // Keep the sync at the beginning of the block
+
+            runTime.run();
 
             #include "readControls.H"
 
@@ -103,10 +104,10 @@ int main(int argc, char *argv[])
             Info << "Coupling iteration = " << iteration << nl << endl;
 
             // Define movement of the coupling interface
-            forAll(boundary_names, s)
+            forAll(boundaryNames, s)
             {
-                word boundary_name = boundary_names[s];
-                ApplyFSIPointDisplacement(mesh, boundary_name);
+                word boundaryName = boundaryNames[s];
+                ApplyFSIPointDisplacement(mesh, boundaryName);
             }
 
             // Do any mesh changes
@@ -147,7 +148,7 @@ int main(int argc, char *argv[])
                 << nl << endl;
 
             // Return the coupling interface output
-            runTime.run();
+            #include "executeCoconutFunctionObjects.H"
 
             Info << "Coupling iteration " << iteration << " end" << nl << endl;
         }

--- a/coupling_components/solver_wrappers/openfoam/v8/coconut_pimpleFoam/coconut_pimpleFoam.C
+++ b/coupling_components/solver_wrappers/openfoam/v8/coconut_pimpleFoam/coconut_pimpleFoam.C
@@ -119,17 +119,17 @@ int main(int argc, char *argv[])
                     {
                         MRF.update();
 
-                        // Calculate absolute flux
-                        // from the mapped surface velocity
-                        phi = mesh.Sf() & Uf();
-
                         if (correctPhi)
                         {
-                            #include "correctPhi.H"
-                        }
+                            // Calculate absolute flux
+                            // from the mapped surface velocity
+                            phi = mesh.Sf() & Uf();
 
-                        // Make the flux relative to the mesh motion
-                        fvc::makeRelative(phi, U);
+                            #include "correctPhi.H"
+
+                            // Make the flux relative to the mesh motion
+                            fvc::makeRelative(phi, U);
+                        }
 
                         if (checkMeshCourantNo)
                         {

--- a/coupling_components/solver_wrappers/openfoam/v8/coconut_pimpleFoam/coconut_pimpleFoam.C
+++ b/coupling_components/solver_wrappers/openfoam/v8/coconut_pimpleFoam/coconut_pimpleFoam.C
@@ -71,17 +71,18 @@ int main(int argc, char *argv[])
     iteration = 0;
 
     IOdictionary controlDict(IOobject("controlDict", runTime.system(), mesh, IOobject::MUST_READ,IOobject::NO_WRITE));
-    wordList boundary_names (controlDict.lookup("boundary_names"));
+    wordList boundaryNames (controlDict.lookup("boundaryNames"));
+    wordList coconutFunctionObjects (controlDict.lookup("coconutFunctionObjects"));
 
-    runTime.functionObjects().start();
-
-    while (true) // NOT (pimple.run(runTime))
+    while (true)
     {
         usleep(1000); // Expressed in microseconds
 
         if (exists("next.coco"))
         {
             waitForSync("next"); // Keep the sync at the beginning of the block
+
+            runTime.run();
 
             #include "readDyMControls.H"
             #include "CourantNo.H"
@@ -101,10 +102,10 @@ int main(int argc, char *argv[])
             Info << "Coupling iteration = " << iteration << nl << endl;
 
             // Define movement of the coupling interface
-            forAll(boundary_names, s)
+            forAll(boundaryNames, s)
             {
-                word boundary_name = boundary_names[s];
-                ApplyFSIPointDisplacement(mesh, boundary_name);
+                word boundaryName = boundaryNames[s];
+                ApplyFSIPointDisplacement(mesh, boundaryName);
             }
 
             // --- Pressure-velocity PIMPLE corrector loop
@@ -158,7 +159,7 @@ int main(int argc, char *argv[])
                 << nl << endl;
 
             // Return the coupling interface output
-            runTime.run();
+            #include "executeCoconutFunctionObjects.H"
 
             Info << "Coupling iteration " << iteration << " end" << nl << endl;
         }

--- a/coupling_components/solver_wrappers/openfoam/v8/coconut_pimpleFoam/coconut_pimpleFoam.C
+++ b/coupling_components/solver_wrappers/openfoam/v8/coconut_pimpleFoam/coconut_pimpleFoam.C
@@ -73,6 +73,8 @@ int main(int argc, char *argv[])
     IOdictionary controlDict(IOobject("controlDict", runTime.system(), mesh, IOobject::MUST_READ,IOobject::NO_WRITE));
     wordList boundary_names (controlDict.lookup("boundary_names"));
 
+    runTime.functionObjects().start();
+
     while (true) // NOT (pimple.run(runTime))
     {
         usleep(1000); // Expressed in microseconds

--- a/coupling_components/solver_wrappers/openfoam/waitForSync.H
+++ b/coupling_components/solver_wrappers/openfoam/waitForSync.H
@@ -4,7 +4,7 @@ void waitForSync(word message)
     // the sequential use of nProcStart and nProcEnd avoids that for one of the processors the label from a previous
     // call still lives and is mistaken for the current one
     {
-        label nProcsStart = 1; // use different label names for start and end, to avoid mix up!
+        label nProcsStart = 1; // use different label names for start and end, to avoid mix up
         label totNprocs = returnReduce(nProcsStart, sumOp<label>()); // sync (gather): wait until all processors reach this point
 
         if (Pstream::master() && (totNprocs == Pstream::nProcs()))

--- a/coupling_components/solver_wrappers/openfoam/waitForSync.H
+++ b/coupling_components/solver_wrappers/openfoam/waitForSync.H
@@ -1,18 +1,28 @@
 void waitForSync(word message)
 {
-   label nProcs = 1;
-   label totNprocs = returnReduce(nProcs, sumOp<label>()); // sync (gather): wait until all processors reach this point
+    // using separate blocks ensures that the labels are restricted to their own scope
+    // the sequential use of nProcStart and nProcEnd avoids that for one of the processors the label from a previous
+    // call still lives and is mistaken for the current one
+    {
+        label nProcsStart = 1; // use different label names for start and end, to avoid mix up!
+        label totNprocs = returnReduce(nProcsStart, sumOp<label>()); // sync (gather): wait until all processors reach this point
 
-   if (Pstream::master() && (totNprocs == Pstream::nProcs()))
-   {
-       word extension = ".coco";
-       word ready = "_ready";
-       fileName file;
+        if (Pstream::master() && (totNprocs == Pstream::nProcs()))
+        {
+            word extension = ".coco";
+            word ready = "_ready";
+            fileName file;
 
-       file = message + ready + extension;
-       OFstream outfile (file);
+            file = message + ready + extension;
+            OFstream outfile (file);
 
-       file = message + extension;
-       rm(file);
-   }
+            file = message + extension;
+            rm(file);
+        }
+    }
+
+    {
+        label nProcsEnd = 1;
+        returnReduce(nProcsEnd, sumOp<label>()); // sync (gather): wait until all processors reach this point
+    }
 }

--- a/examples/breaking_dam/fluent2d_abaqus2d/setup_case.py
+++ b/examples/breaking_dam/fluent2d_abaqus2d/setup_case.py
@@ -1,5 +1,7 @@
+import glob
 import shutil
 import subprocess
+from os.path import join
 
 from coconut import tools
 
@@ -10,6 +12,10 @@ csm_dir = './CSM'
 
 # copy run_simulation.py script to main directory
 shutil.copy('../../run_simulation.py', './')
+
+# clean up Fluent
+if glob.glob(join(cfd_dir, 'cleanup-fluent*')):
+    subprocess.check_call(f'sh cleanup-fluent*', shell=True, cwd=cfd_dir)
 
 # clean working directories
 shutil.rmtree(cfd_dir, ignore_errors=True)

--- a/examples/lid_driven_cavity/fluent2d_kratos_structure2d/setup_case.py
+++ b/examples/lid_driven_cavity/fluent2d_kratos_structure2d/setup_case.py
@@ -1,5 +1,7 @@
+import glob
 import shutil
 import subprocess
+from os.path import join
 
 from coconut import tools
 
@@ -10,6 +12,10 @@ csm_dir = './CSM'
 
 # copy run_simulation.py script to main directory
 shutil.copy('../../run_simulation.py', './')
+
+# clean up Fluent
+if glob.glob(join(cfd_dir, 'cleanup-fluent*')):
+    subprocess.check_call(f'sh cleanup-fluent*', shell=True, cwd=cfd_dir)
 
 # clean working directories
 shutil.rmtree(cfd_dir, ignore_errors=True)

--- a/examples/lid_driven_cavity/setup_files/fluent2d/case.jou
+++ b/examples/lid_driven_cavity/setup_files/fluent2d/case.jou
@@ -57,7 +57,7 @@ solve set discretization-scheme mom 1
 solve set discretization-scheme pressure 12
 solve set p-v-coupling 24
 solve set gradient-scheme y
-solve set reporting-interval 1
+solve set reporting-interval 10
 solve set flow-warnings n
 
 solve initialize set-defaults pressure 0

--- a/examples/test_single_solver/setup_case.py
+++ b/examples/test_single_solver/setup_case.py
@@ -1,5 +1,7 @@
+import glob
 import shutil
 import subprocess
+from os.path import join
 
 from coconut import tools
 
@@ -10,6 +12,10 @@ csm_dir = './CSM'
 
 # copy run_simulation.py script to main directory
 shutil.copy('../run_simulation.py', './')
+
+# clean up Fluent
+if glob.glob(join(cfd_dir, 'cleanup-fluent*')):
+    subprocess.check_call(f'sh cleanup-fluent*', shell=True, cwd=cfd_dir)
 
 # clean working directories
 shutil.rmtree(cfd_dir, ignore_errors=True)

--- a/examples/tube/fluent2d_abaqus2d/setup_case.py
+++ b/examples/tube/fluent2d_abaqus2d/setup_case.py
@@ -1,6 +1,6 @@
+import glob
 import shutil
 import subprocess
-import os
 from os.path import join
 
 from coconut import tools
@@ -12,6 +12,10 @@ csm_dir = './CSM'
 
 # copy run_simulation.py script to main directory
 shutil.copy('../../run_simulation.py', './')
+
+# clean up Fluent
+if glob.glob(join(cfd_dir, 'cleanup-fluent*')):
+    subprocess.check_call(f'sh cleanup-fluent*', shell=True, cwd=cfd_dir)
 
 # clean working directories
 shutil.rmtree(cfd_dir, ignore_errors=True)

--- a/examples/tube/fluent2d_abaqus2d_steady/setup_case.py
+++ b/examples/tube/fluent2d_abaqus2d_steady/setup_case.py
@@ -1,5 +1,7 @@
+import glob
 import shutil
 import subprocess
+from os.path import join
 
 from coconut import tools
 
@@ -10,6 +12,10 @@ csm_dir = './CSM'
 
 # copy run_simulation.py script to main directory
 shutil.copy('../../run_simulation.py', './')
+
+# clean up Fluent
+if glob.glob(join(cfd_dir, 'cleanup-fluent*')):
+    subprocess.check_call(f'sh cleanup-fluent*', shell=True, cwd=cfd_dir)
 
 # clean working directories
 shutil.rmtree(cfd_dir, ignore_errors=True)

--- a/examples/tube/fluent2d_abaqus2d_surrogate/setup_case.py
+++ b/examples/tube/fluent2d_abaqus2d_surrogate/setup_case.py
@@ -1,6 +1,7 @@
+import glob
 import shutil
 import subprocess
-
+from os.path import join
 from coconut import tools
 
 cfd_solver = 'fluent.v2019R3'
@@ -13,6 +14,10 @@ csm_sur_dir = './CSM_surrogate'
 
 # copy run_simulation.py script to main directory
 shutil.copy('../../run_simulation.py', './')
+
+# clean up Fluent
+if glob.glob(join(cfd_dir, 'cleanup-fluent*')):
+    subprocess.check_call(f'sh cleanup-fluent*', shell=True, cwd=cfd_dir)
 
 # clean working directories
 shutil.rmtree(cfd_dir, ignore_errors=True)

--- a/examples/tube/fluent2d_tube_structure/setup_case.py
+++ b/examples/tube/fluent2d_tube_structure/setup_case.py
@@ -1,6 +1,6 @@
+import glob
 import shutil
 import subprocess
-import os
 from os.path import join
 
 from coconut import tools
@@ -11,6 +11,10 @@ csm_dir = './CSM'
 
 # copy run_simulation.py script to main directory
 shutil.copy('../../run_simulation.py', './')
+
+# clean up Fluent
+if glob.glob(join(cfd_dir, 'cleanup-fluent*')):
+    subprocess.check_call(f'sh cleanup-fluent*', shell=True, cwd=cfd_dir)
 
 # clean working directories
 shutil.rmtree(cfd_dir, ignore_errors=True)

--- a/examples/tube/fluent3d_abaqus2d/setup_case.py
+++ b/examples/tube/fluent3d_abaqus2d/setup_case.py
@@ -1,6 +1,6 @@
+import glob
 import shutil
 import subprocess
-import os
 from os.path import join
 
 from coconut import tools
@@ -12,6 +12,10 @@ csm_dir = './CSM'
 
 # copy run_simulation.py script to main directory
 shutil.copy('../../run_simulation.py', './')
+
+# clean up Fluent
+if glob.glob(join(cfd_dir, 'cleanup-fluent*')):
+    subprocess.check_call(f'sh cleanup-fluent*', shell=True, cwd=cfd_dir)
 
 # clean working directories
 shutil.rmtree(cfd_dir, ignore_errors=True)

--- a/examples/tube/fluent3d_abaqus3d/setup_case.py
+++ b/examples/tube/fluent3d_abaqus3d/setup_case.py
@@ -1,6 +1,6 @@
+import glob
 import shutil
 import subprocess
-import os
 from os.path import join
 
 from coconut import tools
@@ -12,6 +12,10 @@ csm_dir = './CSM'
 
 # copy run_simulation.py script to main directory
 shutil.copy('../../run_simulation.py', './')
+
+# clean up Fluent
+if glob.glob(join(cfd_dir, 'cleanup-fluent*')):
+    subprocess.check_call(f'sh cleanup-fluent*', shell=True, cwd=cfd_dir)
 
 # clean working directories
 shutil.rmtree(cfd_dir, ignore_errors=True)

--- a/examples/tube/fluent3d_kratos_structure3d/setup_case.py
+++ b/examples/tube/fluent3d_kratos_structure3d/setup_case.py
@@ -1,6 +1,6 @@
+import glob
 import shutil
 import subprocess
-import os
 from os.path import join
 
 from coconut import tools
@@ -12,6 +12,10 @@ csm_dir = './CSM'
 
 # copy run_simulation.py script to main directory
 shutil.copy('../../run_simulation.py', './')
+
+# clean up Fluent
+if glob.glob(join(cfd_dir, 'cleanup-fluent*')):
+    subprocess.check_call(f'sh cleanup-fluent*', shell=True, cwd=cfd_dir)
 
 # clean working directories
 shutil.rmtree(cfd_dir, ignore_errors=True)

--- a/examples/tube/setup_files/openfoam3d/system/decomposeParDict
+++ b/examples/tube/setup_files/openfoam3d/system/decomposeParDict
@@ -16,7 +16,7 @@ FoamFile
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-numberOfSubdomains   8;
+numberOfSubdomains   4;
 
 method          scotch;
 

--- a/examples/turek/fluent2d_abaqus2d/setup_case.py
+++ b/examples/turek/fluent2d_abaqus2d/setup_case.py
@@ -1,6 +1,6 @@
+import glob
 import shutil
 import subprocess
-import os
 from os.path import join
 
 from coconut import tools
@@ -12,6 +12,10 @@ csm_dir = './CSM'
 
 # copy run_simulation.py script to main directory
 shutil.copy('../../run_simulation.py', './')
+
+# clean up Fluent
+if glob.glob(join(cfd_dir, 'cleanup-fluent*')):
+    subprocess.check_call(f'sh cleanup-fluent*', shell=True, cwd=cfd_dir)
 
 # clean working directories
 shutil.rmtree(cfd_dir, ignore_errors=True)

--- a/examples/turek/fluent2d_abaqus2d_steady/setup_case.py
+++ b/examples/turek/fluent2d_abaqus2d_steady/setup_case.py
@@ -1,5 +1,7 @@
+import glob
 import shutil
 import subprocess
+from os.path import join
 
 from coconut import tools
 
@@ -10,6 +12,10 @@ csm_dir = './CSM'
 
 # copy run_simulation.py script to main directory
 shutil.copy('../../run_simulation.py', './')
+
+# clean up Fluent
+if glob.glob(join(cfd_dir, 'cleanup-fluent*')):
+    subprocess.check_call(f'sh cleanup-fluent*', shell=True, cwd=cfd_dir)
 
 # clean working directories
 shutil.rmtree(cfd_dir, ignore_errors=True)


### PR DESCRIPTION
**Description** 

- Fix possible hang, when processor are not synced properly see issue #204. This is done by performing two gathers with different variable names (existing only in their own scope) one after the other and as such avoiding possible overlap between the existence of these variables from calls of `waitForSync` in different locations in the loop.

- Also make sure other - non-CoCoNuT - functionObjects are only called once per timestep.

- Executing `setup_case.py` for a case using Fluent know first cleans the directory if necessary (sourcing cleanup-fluent*).

**Users' experience affected?** As described above.

**Other parts of the code affected?** NA

**Tests** Relevant (OpenFOAM) tests have been successfully run.

**Related issues** Closes #204 

**Checklist**
- [x] Style guidelines
    1. CoCoNuT follows [the PEP8 style guide](https://www.python.org/dev/peps/pep-0008/).
    2. Comments should be lowercase.
    3. Errors should start with capitals, preferably without punctuation unless it's multiple sentences.
    4. Strings should use single quotes whenever possible.	
- [x] Self-review of code performed
- [x] Code has been commented (particularly in hard-to-understand areas)
- [x] Documentation was updated correspondingly
- [x] New and existing unit tests pass locally with changes
