### PR TITLE
Simplify Fluent UDFs

### DIFF
--- a/coupling_components/solver_wrappers/fluent/v2019R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2019R1.c
@@ -64,7 +64,6 @@ for (_d = 0; _d < dim; _d++) {                                      \
 int _d; /* don't use in UDFs! (overwritten by functions above) */
 int n_threads;
 DECLARE_MEMORY(thread_ids, int);
-int iteration = 0;
 int timestep = 0;
 
 
@@ -357,11 +356,9 @@ DEFINE_ON_DEMAND(store_pressure_traction) {
 #if RP_HOST /* only host process is involved, code not compiled for node */
     char file_name[256];
     FILE *file = NULL;
-    iteration = RP_Get_Integer("udf/iteration"); /* host process reads "udf/iteration" from Fluent (nodes cannot) */
     timestep = RP_Get_Integer("udf/timestep"); /* host process reads "udf/timestep" from Fluent (nodes cannot) */
 #endif /* RP_HOST */
 
-    host_to_node_int_1(iteration); /* host process shares iteration variable with nodes */
     host_to_node_int_1(timestep); /* host process shares timestep variable with nodes */
 
     for (thread=0; thread<n_threads; thread++) { /* both host and node execute loop over face_threads (= ModelParts) */
@@ -529,11 +526,9 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #endif /* RP_NODE */
 
 #if RP_HOST /* only host process is involved, code not compiled for node */
-    iteration = RP_Get_Integer("udf/iteration"); /* host process reads "udf/iteration" from Fluent (nodes cannot) */
     timestep = RP_Get_Integer("udf/timestep"); /* host process reads "udf/timestep" from Fluent (nodes cannot) */
 #endif /* RP_HOST */
 
-    host_to_node_int_1(iteration); /* host process shares iteration variable with nodes */
     host_to_node_int_1(timestep); /* host process shares timestep variable with nodes */
 
 #if RP_HOST /* only host process is involved, code not compiled for node */

--- a/coupling_components/solver_wrappers/fluent/v2019R3.c
+++ b/coupling_components/solver_wrappers/fluent/v2019R3.c
@@ -64,7 +64,6 @@ for (_d = 0; _d < dim; _d++) {                                      \
 int _d; /* don't use in UDFs! (overwritten by functions above) */
 int n_threads;
 DECLARE_MEMORY(thread_ids, int);
-int iteration = 0;
 int timestep = 0;
 
 
@@ -357,11 +356,9 @@ DEFINE_ON_DEMAND(store_pressure_traction) {
 #if RP_HOST /* only host process is involved, code not compiled for node */
     char file_name[256];
     FILE *file = NULL;
-    iteration = RP_Get_Integer("udf/iteration"); /* host process reads "udf/iteration" from Fluent (nodes cannot) */
     timestep = RP_Get_Integer("udf/timestep"); /* host process reads "udf/timestep" from Fluent (nodes cannot) */
 #endif /* RP_HOST */
 
-    host_to_node_int_1(iteration); /* host process shares iteration variable with nodes */
     host_to_node_int_1(timestep); /* host process shares timestep variable with nodes */
 
     for (thread=0; thread<n_threads; thread++) { /* both host and node execute loop over face_threads (= ModelParts) */
@@ -529,11 +526,9 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #endif /* RP_NODE */
 
 #if RP_HOST /* only host process is involved, code not compiled for node */
-    iteration = RP_Get_Integer("udf/iteration"); /* host process reads "udf/iteration" from Fluent (nodes cannot) */
     timestep = RP_Get_Integer("udf/timestep"); /* host process reads "udf/timestep" from Fluent (nodes cannot) */
 #endif /* RP_HOST */
 
-    host_to_node_int_1(iteration); /* host process shares iteration variable with nodes */
     host_to_node_int_1(timestep); /* host process shares timestep variable with nodes */
 
 #if RP_HOST /* only host process is involved, code not compiled for node */

--- a/coupling_components/solver_wrappers/fluent/v2020R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2020R1.c
@@ -64,7 +64,6 @@ for (_d = 0; _d < dim; _d++) {                                      \
 int _d; /* don't use in UDFs! (overwritten by functions above) */
 int n_threads;
 DECLARE_MEMORY(thread_ids, int);
-int iteration = 0;
 int timestep = 0;
 
 
@@ -357,11 +356,9 @@ DEFINE_ON_DEMAND(store_pressure_traction) {
 #if RP_HOST /* only host process is involved, code not compiled for node */
     char file_name[256];
     FILE *file = NULL;
-    iteration = RP_Get_Integer("udf/iteration"); /* host process reads "udf/iteration" from Fluent (nodes cannot) */
     timestep = RP_Get_Integer("udf/timestep"); /* host process reads "udf/timestep" from Fluent (nodes cannot) */
 #endif /* RP_HOST */
 
-    host_to_node_int_1(iteration); /* host process shares iteration variable with nodes */
     host_to_node_int_1(timestep); /* host process shares timestep variable with nodes */
 
     for (thread=0; thread<n_threads; thread++) { /* both host and node execute loop over face_threads (= ModelParts) */
@@ -529,11 +526,9 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #endif /* RP_NODE */
 
 #if RP_HOST /* only host process is involved, code not compiled for node */
-    iteration = RP_Get_Integer("udf/iteration"); /* host process reads "udf/iteration" from Fluent (nodes cannot) */
     timestep = RP_Get_Integer("udf/timestep"); /* host process reads "udf/timestep" from Fluent (nodes cannot) */
 #endif /* RP_HOST */
 
-    host_to_node_int_1(iteration); /* host process shares iteration variable with nodes */
     host_to_node_int_1(timestep); /* host process shares timestep variable with nodes */
 
 #if RP_HOST /* only host process is involved, code not compiled for node */

--- a/coupling_components/solver_wrappers/fluent/v2021R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2021R1.c
@@ -64,7 +64,6 @@ for (_d = 0; _d < dim; _d++) {                                      \
 int _d; /* don't use in UDFs! (overwritten by functions above) */
 int n_threads;
 DECLARE_MEMORY(thread_ids, int);
-int iteration = 0;
 int timestep = 0;
 
 
@@ -357,11 +356,9 @@ DEFINE_ON_DEMAND(store_pressure_traction) {
 #if RP_HOST /* only host process is involved, code not compiled for node */
     char file_name[256];
     FILE *file = NULL;
-    iteration = RP_Get_Integer("udf/iteration"); /* host process reads "udf/iteration" from Fluent (nodes cannot) */
     timestep = RP_Get_Integer("udf/timestep"); /* host process reads "udf/timestep" from Fluent (nodes cannot) */
 #endif /* RP_HOST */
 
-    host_to_node_int_1(iteration); /* host process shares iteration variable with nodes */
     host_to_node_int_1(timestep); /* host process shares timestep variable with nodes */
 
     for (thread=0; thread<n_threads; thread++) { /* both host and node execute loop over face_threads (= ModelParts) */
@@ -529,11 +526,9 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #endif /* RP_NODE */
 
 #if RP_HOST /* only host process is involved, code not compiled for node */
-    iteration = RP_Get_Integer("udf/iteration"); /* host process reads "udf/iteration" from Fluent (nodes cannot) */
     timestep = RP_Get_Integer("udf/timestep"); /* host process reads "udf/timestep" from Fluent (nodes cannot) */
 #endif /* RP_HOST */
 
-    host_to_node_int_1(iteration); /* host process shares iteration variable with nodes */
     host_to_node_int_1(timestep); /* host process shares timestep variable with nodes */
 
 #if RP_HOST /* only host process is involved, code not compiled for node */

--- a/coupling_components/solver_wrappers/fluent/v2021R2.c
+++ b/coupling_components/solver_wrappers/fluent/v2021R2.c
@@ -64,7 +64,6 @@ for (_d = 0; _d < dim; _d++) {                                      \
 int _d; /* don't use in UDFs! (overwritten by functions above) */
 int n_threads;
 DECLARE_MEMORY(thread_ids, int);
-int iteration = 0;
 int timestep = 0;
 
 
@@ -357,11 +356,9 @@ DEFINE_ON_DEMAND(store_pressure_traction) {
 #if RP_HOST /* only host process is involved, code not compiled for node */
     char file_name[256];
     FILE *file = NULL;
-    iteration = RP_Get_Integer("udf/iteration"); /* host process reads "udf/iteration" from Fluent (nodes cannot) */
     timestep = RP_Get_Integer("udf/timestep"); /* host process reads "udf/timestep" from Fluent (nodes cannot) */
 #endif /* RP_HOST */
 
-    host_to_node_int_1(iteration); /* host process shares iteration variable with nodes */
     host_to_node_int_1(timestep); /* host process shares timestep variable with nodes */
 
     for (thread=0; thread<n_threads; thread++) { /* both host and node execute loop over face_threads (= ModelParts) */
@@ -529,11 +526,9 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #endif /* RP_NODE */
 
 #if RP_HOST /* only host process is involved, code not compiled for node */
-    iteration = RP_Get_Integer("udf/iteration"); /* host process reads "udf/iteration" from Fluent (nodes cannot) */
     timestep = RP_Get_Integer("udf/timestep"); /* host process reads "udf/timestep" from Fluent (nodes cannot) */
 #endif /* RP_HOST */
 
-    host_to_node_int_1(iteration); /* host process shares iteration variable with nodes */
     host_to_node_int_1(timestep); /* host process shares timestep variable with nodes */
 
 #if RP_HOST /* only host process is involved, code not compiled for node */

--- a/coupling_components/solver_wrappers/fluent/v2022R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2022R1.c
@@ -64,7 +64,6 @@ for (_d = 0; _d < dim; _d++) {                                      \
 int _d; /* don't use in UDFs! (overwritten by functions above) */
 int n_threads;
 DECLARE_MEMORY(thread_ids, int);
-int iteration = 0;
 int timestep = 0;
 
 
@@ -357,11 +356,9 @@ DEFINE_ON_DEMAND(store_pressure_traction) {
 #if RP_HOST /* only host process is involved, code not compiled for node */
     char file_name[256];
     FILE *file = NULL;
-    iteration = RP_Get_Integer("udf/iteration"); /* host process reads "udf/iteration" from Fluent (nodes cannot) */
     timestep = RP_Get_Integer("udf/timestep"); /* host process reads "udf/timestep" from Fluent (nodes cannot) */
 #endif /* RP_HOST */
 
-    host_to_node_int_1(iteration); /* host process shares iteration variable with nodes */
     host_to_node_int_1(timestep); /* host process shares timestep variable with nodes */
 
     for (thread=0; thread<n_threads; thread++) { /* both host and node execute loop over face_threads (= ModelParts) */
@@ -529,11 +526,9 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #endif /* RP_NODE */
 
 #if RP_HOST /* only host process is involved, code not compiled for node */
-    iteration = RP_Get_Integer("udf/iteration"); /* host process reads "udf/iteration" from Fluent (nodes cannot) */
     timestep = RP_Get_Integer("udf/timestep"); /* host process reads "udf/timestep" from Fluent (nodes cannot) */
 #endif /* RP_HOST */
 
-    host_to_node_int_1(iteration); /* host process shares iteration variable with nodes */
     host_to_node_int_1(timestep); /* host process shares timestep variable with nodes */
 
 #if RP_HOST /* only host process is involved, code not compiled for node */

--- a/coupling_components/solver_wrappers/fluent/v2023R1.c
+++ b/coupling_components/solver_wrappers/fluent/v2023R1.c
@@ -64,7 +64,6 @@ for (_d = 0; _d < dim; _d++) {                                      \
 int _d; /* don't use in UDFs! (overwritten by functions above) */
 int n_threads;
 DECLARE_MEMORY(thread_ids, int);
-int iteration = 0;
 int timestep = 0;
 
 
@@ -357,11 +356,9 @@ DEFINE_ON_DEMAND(store_pressure_traction) {
 #if RP_HOST /* only host process is involved, code not compiled for node */
     char file_name[256];
     FILE *file = NULL;
-    iteration = RP_Get_Integer("udf/iteration"); /* host process reads "udf/iteration" from Fluent (nodes cannot) */
     timestep = RP_Get_Integer("udf/timestep"); /* host process reads "udf/timestep" from Fluent (nodes cannot) */
 #endif /* RP_HOST */
 
-    host_to_node_int_1(iteration); /* host process shares iteration variable with nodes */
     host_to_node_int_1(timestep); /* host process shares timestep variable with nodes */
 
     for (thread=0; thread<n_threads; thread++) { /* both host and node execute loop over face_threads (= ModelParts) */
@@ -529,11 +526,9 @@ DEFINE_GRID_MOTION(move_nodes, domain, dynamic_thread, time, dtime) {
 #endif /* RP_NODE */
 
 #if RP_HOST /* only host process is involved, code not compiled for node */
-    iteration = RP_Get_Integer("udf/iteration"); /* host process reads "udf/iteration" from Fluent (nodes cannot) */
     timestep = RP_Get_Integer("udf/timestep"); /* host process reads "udf/timestep" from Fluent (nodes cannot) */
 #endif /* RP_HOST */
 
-    host_to_node_int_1(iteration); /* host process shares iteration variable with nodes */
     host_to_node_int_1(timestep); /* host process shares timestep variable with nodes */
 
 #if RP_HOST /* only host process is involved, code not compiled for node */


### PR DESCRIPTION
**Description** The UDFs have been updated. Mostly joining MPI compiler directives, as !RP_HOST and RP_NODE are exact opposites since serial mode does not exist anymore. The unused variable `iteration` has been removed.

**Users' experience affected?** No.

**Other parts of the code affected?** No.

**Tests** All tests and examples run and meet benchmark. Also tested example on 1 core.

**Related issues** None.

**Checklist**
- [X] Style guidelines
- [X] Self-review of code performed
- [X] Code has been commented (particularly in hard-to-understand areas)
- [X] Documentation was updated correspondingly
- [X] New and existing unit tests pass locally with changes
