### PR TITLE
Change working directory behavior

### DIFF
--- a/coupling_components/coupled_solvers/coupled_solvers.md
+++ b/coupling_components/coupled_solvers/coupled_solvers.md
@@ -413,8 +413,7 @@ Other dictionaries, used for the actual calculation can be kept, but will not be
 The `settings` dictionary is used to look up `delta_t`, `timestep_start`, `save_results` and `case_name` if not provided in `test_settings`. Note that `test_settings` has priority over the parameters defined in `settings`. This means a calculation can be tested, by only adding the `test_settings` dictionary and changing the coupled solver `type` to `coupled_solvers.test_single_solver` and without altering anything else.
 An illustration can be found in the example [test_single_solver](../../examples/test_single_solver/test_single_solver.md).
 
-The working directory of the solver is copied to a new directory with the same name and a suffix `_testX` with `X` an integer starting from 0. As such, previous test solver working directories are not overwritten.
-The optional pickle file, which saves some [results](#save-results), uses the name as specified by the JSON settings followed by an underscore and the solver test working directory. As such, the pickle file can always be linked to the corresponding test working directory.
+The optional pickle file, which saves some [results](#save-results), uses the name as specified by the JSON settings followed by an underscore and the solver working directory.
 
 During run time, the norm of $x$ and $y$ are printed. A residual does not exist here. The arrays $x$ and $y$ do not have a physical meaning, but are the in- and output of the first solver, which is typically the flow solver. Then, the vector $y$ will contain pressure and traction components for all points. Nonetheless, these values can be useful to verify that the solver wrapper runs.
 

--- a/coupling_components/coupled_solvers/test_single_solver.py
+++ b/coupling_components/coupled_solvers/test_single_solver.py
@@ -51,15 +51,6 @@ class CoupledSolverTestSingleSolver(CoupledSolver):
             parameters = parameters['settings']['solver_wrapper']  # for mapped solver: the solver_wrapper itself tested
         settings = parameters['settings']
 
-        orig_wd = settings['working_directory']  # working directory changed to a test_working_directory
-        i = 0
-        while os.path.exists(f'{orig_wd}_test{i}'):
-            i += 1
-        cur_wd = f'{orig_wd}_test{i}'
-        settings['working_directory'] = cur_wd
-        os.system(f'cp -r {orig_wd} {cur_wd}')
-        tools.print_info(f'{cur_wd} is the working_directory for the test\nCopying {orig_wd} to {cur_wd} \n')
-
         # add delta_t and timestep_start to solver_wrapper settings
         tools.pass_on_parameters(self.settings, parameters['settings'], ['timestep_start', 'delta_t', 'save_restart'])
 
@@ -87,7 +78,7 @@ class CoupledSolverTestSingleSolver(CoupledSolver):
             self.residual = []
             self.info = None
             self.case_name = self.settings.get('case_name', 'case')  # case name
-            self.case_name += '_' + cur_wd
+            self.case_name += '_' + settings['working_directory']  # add working directory to pickle file name
 
         if self.settings.get('debug', False):
             tools.print_info(f'{self.__class__.__name__} has no debug mode: '


### PR DESCRIPTION
**Description** The coupled solver test_single_solver no longers copies the working directory to a new one appended with test_x, but simply calculates in the provided one, as do the other coupled solvers.

**Users' experience affected?** The working directories and pickle files will be overwritten when test_single_solver is used to run a case multiple times.

**Other parts of the code affected?** Not applicable.

**Tests** Relevant example has been tested.

**Related issues** Closes #223 

**Checklist**
- [x] Style guidelines
    1. CoCoNuT follows [the PEP8 style guide](https://www.python.org/dev/peps/pep-0008/).
    2. Comments should be lowercase.
    3. Errors should start with capitals, preferably without punctuation unless it's multiple sentences.
    4. Strings should use single quotes whenever possible.	
- [x] Self-review of code performed
- [x] Code has been commented (particularly in hard-to-understand areas)
- [x] Documentation was updated correspondingly
- [x] New and existing unit tests pass locally with changes
