### PR TITLE
Add reporting of time required to save

### DIFF
--- a/coupling_components/component.py
+++ b/coupling_components/component.py
@@ -2,6 +2,9 @@ from coconut import tools
 
 
 class Component(object):
+    mapped = False
+    dummy = False
+
     def __init__(self):
         self.initialized = False
         self.initialized_solution_step = False

--- a/coupling_components/convergence_criteria/dummy_convergence_criterion.py
+++ b/coupling_components/convergence_criteria/dummy_convergence_criterion.py
@@ -6,6 +6,8 @@ def create(parameters):
 
 
 class ConvergenceCriterionDummy(Component):
+    dummy = True
+
     def __init__(self, _):
         super().__init__()
 
@@ -14,4 +16,4 @@ class ConvergenceCriterionDummy(Component):
 
     def is_satisfied(self):
         raise NotImplementedError('is_satisfied() called for ConvergenceCriterionDummy,'
-                                  ' use another convegence_criterion')
+                                  ' use another convergence_criterion')

--- a/coupling_components/coupled_solvers/coupled_solver.py
+++ b/coupling_components/coupled_solvers/coupled_solver.py
@@ -61,6 +61,7 @@ class CoupledSolver(Component):
         self.start_run_time = None
         self.run_time = None
         self.run_time_previous = 0
+        self.save_time = 0
         self.time_allocation = {'previous_calculations': []}
         self.iterations = []
 
@@ -82,7 +83,7 @@ class CoupledSolver(Component):
         if self.debug:
             self.complete_solution_r = None
 
-    def initialize(self):
+    def initialize(self, print_components=True):
         super().initialize()
 
         # initialize mappers if required
@@ -104,7 +105,8 @@ class CoupledSolver(Component):
             title = '\n╔' + 78 * '═' + f'╗\n║{self.case_name.upper():^78}║\n╚' + 78 * '═' + '╝\n'
             tools.print_info(title)
 
-        self.print_components_info(' ')
+        if print_components and self.solver_level == 0:
+            self.print_components_info(' ')
 
         # restart
         if self.restart:
@@ -159,7 +161,10 @@ class CoupledSolver(Component):
         self.iteration += 1  # increment iteration
         self.convergence_criterion.update(r.copy())  # update convergence criterion
         self.print_iteration_info(r)  # print iteration information
+        self.output_iteration(r)
 
+    @tools.time_save
+    def output_iteration(self, r):
         # update save results
         if self.save_results:
             self.residual[self.time_step - self.timestep_start_global - 1].append(r.norm())
@@ -177,6 +182,13 @@ class CoupledSolver(Component):
         self.predictor.update(self.x)
         for component in self.components:
             component.finalize_solution_step()
+
+    @tools.time_save
+    def output_solution_step(self):
+        super().output_solution_step()
+
+        for component in self.components:
+            component.output_solution_step()
 
         # save data for restart
         if self.save_restart != 0 and self.time_step % self.save_restart == 0:
@@ -198,12 +210,10 @@ class CoupledSolver(Component):
                 self.complete_solution_y = np.hstack((self.complete_solution_y,
                                                       self.y.get_interface_data().reshape(-1, 1)))
 
-    def output_solution_step(self):
-        super().output_solution_step()
-
-        self.time_allocation.update(self.get_time_allocation())
+        # output save results
         if self.save_results != 0 and (self.time_step % self.save_results == 0 or
                                        (self.save_restart != 0 and self.time_step % self.save_restart == 0)):
+            self.time_allocation.update(self.get_time_allocation())
             output = {'solution_x': self.complete_solution_x, 'solution_y': self.complete_solution_y,
                       'interface_x': self.x, 'interface_y': self.y, 'iterations': self.iterations,
                       'residual': self.residual, 'run_time': self.run_time + self.run_time_previous,
@@ -216,21 +226,17 @@ class CoupledSolver(Component):
             with open(self.case_name + '_results.pickle', 'wb') as file:
                 pickle.dump(output, file)
 
-        for component in self.components:
-            component.output_solution_step()
-
     def finalize(self):
         super().finalize()
 
-        # print summary header
-        if self.solver_level == 0:
-            out = '╔' + 79 * '═' + '\n║\tSummary\n╠' + 79 * '═'
-            tools.print_info(out)
+        time_allocation = self.get_time_allocation()  # the save time for the coupling will have changed
 
         for component in self.components:
             component.finalize()
 
-        self.print_summary()
+        # print summary
+        if self.solver_level == 0:
+            self.print_summary(time_allocation)
 
     def load_restart_data(self):
         restart_file_name = self.restart_case + f'_restart_ts{self.timestep_start_current}.pickle'
@@ -275,6 +281,7 @@ class CoupledSolver(Component):
                              f"\n\tnew: {self.delta_t}s")
         return continue_check
 
+    @tools.time_save
     def save_restart_data(self):
         restart_data = {'predictor': self.predictor.save_restart_data(), 'interface_x': self.x, 'interface_y': self.y,
                         'parameters': {key: self.parameters[key] for key in ('type', 'settings', 'predictor')},
@@ -315,57 +322,78 @@ class CoupledSolver(Component):
             self.complete_solution_r = results_data['solution_r']
         return results_data
 
-    def print_summary(self):
-        solver_init_time_percs = []
-        solver_run_time_percs = []
+    def print_summary(self, time_allocation):
         pre = '║' + ' │' * self.solver_level
-        out = ''
-        if self.solver_level == 0:
-            out += f'{pre}Total calculation time{" (after restart)" if self.restart else ""}:' \
-                   f' {self.init_time + self.run_time:.3f}s\n'
+
+        out = '╔' + 79 * '═' + '\n║\tSummary\n╠' + 79 * '═' + '\n'
+        out += f'{pre}Total calculation time{" (after restart)" if self.restart else ""}: ' \
+               f'{time_allocation["total"]:.3f}s\n'
+
         # initialization time
-        if self.solver_level == 0:
-            out += f'{pre}Initialization time: {self.init_time:0.3f}s\n'
+        out += f'{pre}Initialization time: {time_allocation["init_time"]["total"]:0.3f}s\n'
         out += f'{pre}Distribution of initialization time:\n'
-        for solver in self.solver_wrappers:
-            solver_init_time_percs.append(solver.init_time / self.init_time * 100)
-            out += f'{pre}\t{solver.__class__.__name__}: {solver.init_time:.0f}s ({solver_init_time_percs[-1]:0.1f}%)\n'
-            if solver.__class__.__name__ == 'SolverWrapperMapped':
-                out += f'{pre}\t└─{solver.solver_wrapper.__class__.__name__}: {solver.solver_wrapper.init_time:.0f}s' \
-                       f' ({solver.solver_wrapper.init_time / self.init_time * 100:0.1f}%)\n'
-        if self.solver_level == 0:
-            out += f'{pre}\tOther: {self.init_time - sum([s.init_time for s in self.solver_wrappers]):.0f}s' \
-                   f' ({100 - sum(solver_init_time_percs):0.1f}%)\n'
+        out += self.print_time_distribution(time_allocation['init_time'], pre + '  ')
+
         # run time
-        if self.solver_level == 0:
-            out += f'{pre}Run time{" (after restart)" if self.restart else ""}: {self.run_time:0.3f}s\n'
+        out += f'{pre}Run time{" (after restart)" if self.restart else ""}: ' \
+               f'{time_allocation["run_time"]["total"]:0.3f}s\n'
         out += f'{pre}Distribution of run time:\n'
-        for solver in self.solver_wrappers:
-            solver_run_time_percs.append(solver.run_time / self.run_time * 100)
-            out += f'{pre}\t{solver.__class__.__name__}: {solver.run_time:.0f}s ({solver_run_time_percs[-1]:0.1f}%)\n'
-            if solver.__class__.__name__ == 'SolverWrapperMapped':
-                out += f'{pre}\t└─{solver.solver_wrapper.__class__.__name__}: {solver.solver_wrapper.run_time:.0f}s' \
-                       f' ({solver.solver_wrapper.run_time / self.run_time * 100:0.1f}%)\n'
-        if self.solver_level == 0:
-            out += f'{pre}\tCoupling: {self.run_time - sum([s.run_time for s in self.solver_wrappers]):.0f}s' \
-                   f' ({100 - sum(solver_run_time_percs):0.1f}%)\n'
+        out += self.print_time_distribution(time_allocation['run_time'], pre + '  ', last=False)
+
+        # save time (part of the run time)
+        reference = time_allocation['run_time']['total']
+        ta_save = time_allocation['run_time']['save_time']
+        out += f'{pre}  └─Save time: {ta_save["total"]:.0f}s ({ta_save["total"] / reference * 100:0.1f}%)\n'
+        out += self.print_time_distribution(ta_save, pre + '    ', reference=reference)
+
         out += f'{pre}Average number of iterations per time step' \
                f'{" (including before restart)" if self.restart else ""}: {np.array(self.iterations).mean():0.2f}'
-        if self.solver_level == 0:
-            out += '\n╚' + 79 * '═'
+        out += '\n╚' + 79 * '═'
         tools.print_info(out)
 
     def get_time_allocation(self):
         self.run_time = time.time() - self.start_run_time  # duration of calculation
         time_allocation = {'total': self.run_time + self.init_time}
-        for time_type in ('init_time', 'run_time'):
+        for time_type in ('init_time', 'run_time', 'save_time'):
             time_allocation_sub = time_allocation[time_type] = {}
             time_allocation_sub['total'] = self.__getattribute__(time_type)
             for i, solver_wrapper in enumerate(self.solver_wrappers):
                 time_allocation_sub[f'solver_wrapper_{i}'] = solver_wrapper.get_time_allocation()[time_type]
-            time_allocation_sub['other'] = self.__getattribute__(time_type) - sum(
+            time_allocation_sub['coupling'] = self.__getattribute__(time_type) - sum(
                 [s.__getattribute__(time_type) for s in self.solver_wrappers])
+        self.add_time_allocation(time_allocation)
+        if self.solver_level == 0:
+            time_allocation_save = time_allocation['run_time']['save_time'] = time_allocation.pop('save_time')
+            time_allocation['run_time']['coupling'] = time_allocation['run_time']['coupling'] \
+                - time_allocation_save['total']
         return time_allocation
+
+    def add_time_allocation(self, time_allocation):
+        pass
+
+    def print_time_distribution(self, ta, pre, reference=None, last=True):
+        out = ''
+        if reference is None:
+            reference = ta['total']
+        for i, solver in enumerate(self.solver_wrappers):
+            ta_solver = ta[f'solver_wrapper_{i}']
+            if isinstance(ta_solver, float):
+                out += f'{pre}├─{solver.__class__.__name__}: {ta_solver:.0f}s ({ta_solver / reference * 100:0.1f}%)\n'
+            else:
+                out += f'{pre}├─{solver.__class__.__name__}: {ta_solver["total"]:.0f}s ' \
+                       f'({ta_solver["total"] / reference * 100:0.1f}%)\n'
+                if solver.mapped:
+                    out += f'{pre}│ └─{solver.solver_wrapper.__class__.__name__}: ' \
+                           f'{ta_solver["solver_wrapper"]:.0f}s ' \
+                           f'({ta_solver["solver_wrapper"] / reference * 100:0.1f}%)\n'
+        out += self.add_time_distribution(ta, pre, reference)
+        out += f'{pre}{"└" if last else "├"}─Coupling: {ta["coupling"]:.0f}s ' \
+               f'({ta["coupling"] / reference * 100:0.1f}%)\n'
+        return out
+
+    @staticmethod
+    def add_time_distribution(*_):
+        return ''
 
     def print_header(self):
         header = (80 * '═' + f'\n\tTime step {self.time_step}\n' +

--- a/coupling_components/coupled_solvers/coupled_solvers.md
+++ b/coupling_components/coupled_solvers/coupled_solvers.md
@@ -505,8 +505,8 @@ The physical effect of previous time steps dealt with by the solver wrappers.
 **Therefore, in order to be able to perform a restart, the solver files for the corresponding time step also need to be present!**
 
 When performing restart, the new data will be neatly appended to the already existing results pickle file, leaving out existing time step data after the new time step start.
-As a result, the results pickle file looks exactly as if the calculation was never stopped, with the exception of the fields `run_time` and `info`.
-The latter provides a very shot log of when restart is performed.
+As a result, the results pickle file looks exactly as if the calculation was never stopped, except the fields `run_time`, `time_allocation` and `info`.
+The latter provides a very short log of when restart is performed.
 
 If the results pickle file would not be found for any reason, the user is informed and a new one is made, with the correct `timestep_start`.
 Note that the presence of the restart pickle file on the other hand is required. If the `case_name` is changed, the restart can still be performed by providing the case name for restart using `restart_case` (see explanation above).

--- a/coupling_components/coupled_solvers/ibqn.py
+++ b/coupling_components/coupled_solvers/ibqn.py
@@ -31,7 +31,7 @@ class CoupledSolverIBQN(CoupledSolver):
         self.restart_models = [False, False]  # indicates if model_f and/or model_s have to be restarted
 
     def initialize(self):
-        super().initialize()
+        super().initialize(print_components=False)
 
         self.dxtemp = self.x.copy()
         self.dytemp = self.y.copy()
@@ -48,6 +48,9 @@ class CoupledSolverIBQN(CoupledSolver):
             if self.restart_models[i]:  # restart with the same model type
                 model.restart(self.restart_data[model_name])
             self.components += [model]
+
+        if self.solver_level == 0:
+            self.print_components_info(' ')
 
     def lop_f(self, dx):
         self.dxtemp.set_interface_data(dx.flatten())

--- a/coupling_components/coupled_solvers/iqni.py
+++ b/coupling_components/coupled_solvers/iqni.py
@@ -19,7 +19,7 @@ class CoupledSolverIQNI(CoupledSolver):
         self.restart_model = False  # indicates if model has to be restarted
 
     def initialize(self):
-        super().initialize()
+        super().initialize(print_components=False)
 
         self.model.size_in = self.model.size_out = self.x.size
         self.model.out = self.x.copy()
@@ -27,6 +27,9 @@ class CoupledSolverIQNI(CoupledSolver):
         if self.restart_model:  # restart with the same model type
             self.model.restart(self.restart_data['model'])
         self.components += [self.model]
+
+        if self.solver_level == 0:
+            self.print_components_info(' ')
 
     def solve_solution_step(self):
         # initial value

--- a/coupling_components/coupled_solvers/models/dummy_model.py
+++ b/coupling_components/coupled_solvers/models/dummy_model.py
@@ -9,6 +9,7 @@ def create(parameters):
 class ModelDummy(Component):
     provides_get_solution = True
     provides_set_solution = False
+    dummy = True
 
     @tools.time_initialize
     def __init__(self, _):
@@ -20,6 +21,7 @@ class ModelDummy(Component):
         # noinspection PyUnresolvedReferences
         self.init_time = self.init_time  # created by decorator time_initialize
         self.run_time = 0.0
+        self.save_time = 0.0
 
     @tools.time_solve_solution_step
     def get_solution(self):
@@ -33,6 +35,10 @@ class ModelDummy(Component):
         out = f'{pre} └{(78 - len(pre)) * "─"}\n' \
               f'{pre}{"Iteration":<16}{"Norm residual":<28}'
         tools.print_info(out)
+
+    @tools.time_save
+    def output_solution_step(self):
+        super().output_solution_step()
 
     # noinspection PyMethodMayBeStatic
     def predict(self, dr, **_):
@@ -59,4 +65,4 @@ class ModelDummy(Component):
         pass
 
     def get_time_allocation(self):
-        return {'init_time': self.init_time, 'run_time': self.run_time}
+        return {'init_time': self.init_time, 'run_time': self.run_time, 'save_time': self.save_time}

--- a/coupling_components/coupled_solvers/models/surrogate.py
+++ b/coupling_components/coupled_solvers/models/surrogate.py
@@ -30,6 +30,7 @@ class ModelSurrogate(Component):
         # noinspection PyUnresolvedReferences
         self.init_time = self.init_time  # created by decorator time_initialize
         self.run_time = 0.0
+        self.save_time = 0.0
 
     @tools.time_initialize
     def initialize(self):
@@ -48,17 +49,16 @@ class ModelSurrogate(Component):
 
         self.coupled_solver.finalize_solution_step()
 
+    @tools.time_save
+    def output_solution_step(self):
+        super().output_solution_step()
+
+        self.coupled_solver.output_solution_step()
+
     def finalize(self):
         super().finalize()
 
-        pre = '║' + ' │' * (self.solver_level - 1)
-        out = f'{pre} ┌{(78 - len(pre)) * "─"}\n' \
-              f'{pre} │\tSummary surrogate\n' \
-              f'{pre} ├{(78 - len(pre)) * "─"}'
-        tools.print_info(out)
         self.coupled_solver.finalize()
-        out = f'{pre} └{(78 - len(pre)) * "─"}'
-        tools.print_info(out)
 
     @tools.time_solve_solution_step
     def get_solution(self):
@@ -105,11 +105,6 @@ class ModelSurrogate(Component):
     def get_interface_output(self):
         return self.coupled_solver.x.copy()
 
-    def output_solution_step(self):
-        super().output_solution_step()
-
-        self.coupled_solver.output_solution_step()
-
     def restart(self, restart_data):
         pass
 
@@ -121,18 +116,21 @@ class ModelSurrogate(Component):
 
     def get_time_allocation(self):
         time_allocation = {}
-        for time_type in ('init_time', 'run_time'):
+        for time_type in ('init_time', 'run_time', 'save_time'):
             total_time = self.__getattribute__(time_type)
             coupled_solver_time = self.coupled_solver.get_time_allocation()[time_type]
             solution_time = coupled_solver_time.pop('total') - coupled_solver_time.pop(
-                'other')  # time for solver, surrogates etc
+                'coupling')  # time for solver, surrogates etc
             other_time = total_time - solution_time
             time_allocation[time_type] = {'total': total_time}
             time_allocation[time_type].update(coupled_solver_time)
-            time_allocation[time_type].update({'other': other_time})
+            time_allocation[time_type].update({'coupling': other_time})
         return time_allocation
 
     def print_components_info(self, pre):
         tools.print_info(pre, 'The component ', self.__class__.__name__, ' with the following CoupledSolver:')
         pre = tools.update_pre(pre)
         self.coupled_solver.print_components_info(pre + '└─')
+
+    def print_time_distribution(self, ta, pre, reference=None, last=True):
+        return self.coupled_solver.print_time_distribution(ta, pre, reference=reference, last=last)

--- a/coupling_components/coupling_components.md
+++ b/coupling_components/coupling_components.md
@@ -16,8 +16,8 @@ Detailed information on these components can be found in the specific documentat
 
 All these coupling components inherit from a same superclass called `Component`, defined in *`coconut/coupling_components/component.py`*. 
 In this class some methods are implemented, which control the flow within CoCoNuT. 
-For every coupling component, there are `initialize` and `finalize`, which are called at the start and end of a calculation
-and there are `initialize_solution_step` and `finalize_solution_step`, which are called at the start and end of each time step.
+For every coupling component, there are `initialize` and `finalize`, which are called at the start and end of a calculation,
+as well as `initialize_solution_step`, called at the start of each time step, and `finalize_solution_step` and `output_solution_step`, both called at the end of each time step.
 If needed these methods are overwritten to perform a specific action.
 For example in the `finalize` method of a `solver_wrapper`, the termination of the solver software could be implemented.
 
@@ -34,11 +34,21 @@ For these `Interface` objects (implemented in *`coconut/data_structure/interface
 The main coupling component in which all other coupling components are instantiated is the coupled solver.
 The coupled solver itself is created in the `Analysis` class (*`coconut/analysis.py`*), which is the starting point of the CoCoNuT calculation.
 Upon the start of CoCoNuT, an instance of `Analysis` is made and its method `run` is executed.
-The coupled solver keeps track of all `Components` and runs the methods `initialize`, `finalize`, `initialize_solution_step` and `finalize_solution_step`,
+The coupled solver keeps track of all `Components` and runs the methods `initialize`, `finalize`, `initialize_solution_step`, `finalize_solution_step` and `output_solution_step`,
 when its respective methods are executed.
+
+## End of the calculation
+
+At the end of the calculation a summary will be printed by the coupled solver.
+Next to the average number of coupling iterations per time step required to reach convergence, it provides an overview of the computational time.
+The total calculation time is split in the time required for initialization and the actual run time.
+For both, the distribution over the different components is reported as well, for example, the run time of a `solver_wrapper` is the time spend in the `solve_solution_step` method.
+The part of the run time required for saving data is shown separately, and once more the distribution over the different components are shown.
+This so-called save time is the time spend in the method `output_solution_step`.
+This information allows to assess which part of the calculation is taking the most time and shows how to potentially reduce the calculation time.
 
 ## Tools
 
 Some code to perform specific tasks, like printing with a certain layout or performing a time measurement is useful throughout the code.
 These functionalities are grouped in the file *`coconut/tools.py`*.
-It suffices to import the file to make uses of its functions.
+It suffices to import the file to make use of its functions.

--- a/coupling_components/solver_wrappers/abaqus/abaqus.py
+++ b/coupling_components/solver_wrappers/abaqus/abaqus.py
@@ -419,6 +419,10 @@ class SolverWrapperAbaqus(SolverWrapper):
         for f in self.dir_vault.iterdir():
             f.unlink()  # empty vault
 
+    @tools.time_save
+    def output_solution_step(self):
+        super().output_solution_step()
+
     def finalize(self):
         super().finalize()
         if self.save_restart == 0 or self.timestep % self.save_restart != 0:  # no files needed for restart

--- a/coupling_components/solver_wrappers/combined.py
+++ b/coupling_components/solver_wrappers/combined.py
@@ -101,12 +101,12 @@ class SolverWrapperCombined(Component):
 
     def get_time_allocation(self):
         time_allocation = {}
-        for time_type in ('init_time', 'run_time'):
+        for time_type in ('init_time', 'run_time', 'save_time'):
             time_allocation_sub = time_allocation[time_type] = {}
             time_allocation_sub['total'] = self.__getattribute__(time_type)
             for i, solver_wrapper in enumerate(self.solver_wrappers):
                 time_allocation_sub[f'solver_wrapper_{i}'] = solver_wrapper.get_time_allocation()[time_type]
-            time_allocation_sub['other'] = self.__getattribute__(time_type) - sum(
+            time_allocation_sub['coupling'] = self.__getattribute__(time_type) - sum(
                 [s.__getattribute__(time_type) for s in self.solver_wrappers])
         return time_allocation
 

--- a/coupling_components/solver_wrappers/fluent/fluent.py
+++ b/coupling_components/solver_wrappers/fluent/fluent.py
@@ -360,6 +360,10 @@ class SolverWrapperFluent(SolverWrapper):
     def finalize_solution_step(self):
         super().finalize_solution_step()
 
+    @tools.time_save
+    def output_solution_step(self):
+        super().output_solution_step()
+
         # save if required
         if (self.save_results != 0 and self.timestep % self.save_results == 0) \
                 or (self.save_restart != 0 and self.timestep % self.save_restart == 0):

--- a/coupling_components/solver_wrappers/kratos_structure/kratos_structure.py
+++ b/coupling_components/solver_wrappers/kratos_structure/kratos_structure.py
@@ -106,6 +106,11 @@ class SolverWrapperKratosStructure(SolverWrapper):
 
     def finalize_solution_step(self):
         super().finalize_solution_step()
+
+    @tools.time_save
+    def output_solution_step(self):
+        super().output_solution_step()
+
         self.coco_messages.send_message('save')
         self.coco_messages.wait_message('save_ready')
         if self.residual_variables is not None:
@@ -113,6 +118,7 @@ class SolverWrapperKratosStructure(SolverWrapper):
 
     def finalize(self):
         super().finalize()
+
         self.coco_messages.send_message('stop')
         self.coco_messages.wait_message('stop_ready')
         self.coco_messages.remove_all_messages()

--- a/coupling_components/solver_wrappers/mapped.py
+++ b/coupling_components/solver_wrappers/mapped.py
@@ -8,6 +8,8 @@ def create(parameters):
 
 
 class SolverWrapperMapped(Component):
+    mapped = True
+
     @tools.time_initialize
     def __init__(self, parameters):
         super().__init__()
@@ -33,6 +35,7 @@ class SolverWrapperMapped(Component):
         # noinspection PyUnresolvedReferences
         self.init_time = self.init_time  # created by decorator time_initialize
         self.run_time = 0.0
+        self.save_time = 0.0
 
     @tools.time_initialize
     def initialize(self, interface_input_from, interface_output_to):
@@ -68,19 +71,20 @@ class SolverWrapperMapped(Component):
 
         self.solver_wrapper.finalize_solution_step()
 
-    def finalize(self):
-        super().finalize()
-
-        self.solver_wrapper.finalize()
-        self.mapper_interface_input.finalize()
-        self.mapper_interface_output.finalize()
-
+    @tools.time_save
     def output_solution_step(self):
         super().output_solution_step()
 
         self.solver_wrapper.output_solution_step()
         self.mapper_interface_input.output_solution_step()
         self.mapper_interface_output.output_solution_step()
+
+    def finalize(self):
+        super().finalize()
+
+        self.solver_wrapper.finalize()
+        self.mapper_interface_input.finalize()
+        self.mapper_interface_output.finalize()
 
     def get_interface_input(self):
         # does not contain most recent data
@@ -93,7 +97,7 @@ class SolverWrapperMapped(Component):
 
     def get_time_allocation(self):
         time_allocation = {}
-        for time_type in ('init_time', 'run_time'):
+        for time_type in ('init_time', 'run_time', 'save_time'):
             total_time = self.__getattribute__(time_type)
             solver_wrapper_time = self.solver_wrapper.get_time_allocation()[time_type]
             mapper_time = total_time - (

--- a/coupling_components/solver_wrappers/openfoam/openfoam.py
+++ b/coupling_components/solver_wrappers/openfoam/openfoam.py
@@ -306,6 +306,11 @@ class SolverWrapperOpenFOAM(SolverWrapper):
 
     def finalize_solution_step(self):
         super().finalize_solution_step()
+
+    @tools.time_save
+    def output_solution_step(self):
+        super().output_solution_step()
+
         if not self.debug:
             for boundary in self.boundary_names:
                 post_process_time_folder = os.path.join(self.working_directory,

--- a/coupling_components/solver_wrappers/python/tube_flow_solver.py
+++ b/coupling_components/solver_wrappers/python/tube_flow_solver.py
@@ -227,10 +227,10 @@ class SolverWrapperTubeFlow(SolverWrapper):
     def finalize_solution_step(self):
         super().finalize_solution_step()
 
-    def finalize(self):
-        super().finalize()
-
+    @tools.time_save
     def output_solution_step(self):
+        super().output_solution_step()
+
         if self.n > 0 and self.save_restart != 0 and self.n % self.save_restart == 0:
             file_name = join(self.working_directory, f'case_timestep{self.n}.pickle')
             with open(file_name, 'wb') as file:
@@ -248,6 +248,9 @@ class SolverWrapperTubeFlow(SolverWrapper):
                 file.write(f"{'z-coordinate':<22}\t{'pressure':<22}\t{'velocity':<22}\n")
                 for i in range(len(self.z)):
                     file.write(f'{self.z[i]:<22}\t{p[i]:<22}\t{u[i]:<22}\n')
+
+    def finalize(self):
+        super().finalize()
 
     def get_inlet_boundary(self):
         if self.inlet_type == 1:

--- a/coupling_components/solver_wrappers/python/tube_ringmodel_solver.py
+++ b/coupling_components/solver_wrappers/python/tube_ringmodel_solver.py
@@ -125,13 +125,16 @@ class SolverWrapperTubeRingmodel(SolverWrapper):
     def finalize_solution_step(self):
         super().finalize_solution_step()
 
-    def finalize(self):
-        super().finalize()
-
+    @tools.time_save
     def output_solution_step(self):
+        super().output_solution_step()
+
         if self.debug:
             file_name = join(self.working_directory, f'area_ts{self.n}.txt')
             with open(file_name, 'w') as file:
                 file.write(f"{'z-coordinate':<22}\t{'area':<22}\n")
                 for i in range(len(self.z)):
                     file.write(f'{self.z[i]:<22}\t{self.a[i]:<22}\n')
+
+    def finalize(self):
+        super().finalize()

--- a/coupling_components/solver_wrappers/python/tube_structure_solver.py
+++ b/coupling_components/solver_wrappers/python/tube_structure_solver.py
@@ -198,10 +198,10 @@ class SolverWrapperTubeStructure(SolverWrapper):
                           - self.rndot / (self.beta * self.dt) - self.rnddot * (1 / (2 * self.beta) - 1) * self.nm)
             self.rdot = self.rndot + self.dt * (1 - self.gamma) * self.rnddot + self.dt * self.gamma * self.rddot
 
-    def finalize(self):
-        super().finalize()
-
+    @tools.time_save
     def output_solution_step(self):
+        super().output_solution_step()
+
         if self.n > 0 and self.save_restart != 0 and self.n % self.save_restart == 0:
             file_name = join(self.working_directory, f'case_timestep{self.n}.pickle')
             with open(file_name, 'wb') as file:
@@ -217,6 +217,9 @@ class SolverWrapperTubeStructure(SolverWrapper):
                 file.write(f"{'z-coordinate':<22}\t{'area':<22}\n")
                 for i in range(len(self.z)):
                     file.write(f'{self.z[i]:<22}\t{self.a[i]:<22}\n')
+
+    def finalize(self):
+        super().finalize()
 
     def get_residual(self):
         f = np.zeros(self.m + 4)

--- a/coupling_components/solver_wrappers/solver_wrapper.py
+++ b/coupling_components/solver_wrappers/solver_wrapper.py
@@ -12,6 +12,7 @@ class SolverWrapper(Component):
         # noinspection PyUnresolvedReferences
         self.init_time = self.init_time  # created by decorator time_initialize
         self.run_time = 0.0
+        self.save_time = 0.0
 
         # debug
         self.settings = parameters['settings']
@@ -24,4 +25,4 @@ class SolverWrapper(Component):
         return self.interface_output.copy()
 
     def get_time_allocation(self):
-        return {'init_time': self.init_time, 'run_time': self.run_time}
+        return {'init_time': self.init_time, 'run_time': self.run_time, 'save_time': self.save_time}

--- a/coupling_components/solver_wrappers/solver_wrappers.md
+++ b/coupling_components/solver_wrappers/solver_wrappers.md
@@ -5,13 +5,14 @@ implement a way to communicate input to the solver (at the fluid-structure inter
 input and obtain the solution from the solver (at the fluid-structure interface).
 
 **Important**: To avoid conflicts, each solver is run in its own environment. These environments are established on
-runtime, but the actions required to do so can differ between systems. Therefore it is necessary to first check (and if
+runtime, but the actions required to do so can differ between systems. Therefore, it is necessary to first check (and if
 needed adapt) the file *`coconut/solver_modules.py`* after installing or updating CoCoNuT, as described
 in [the front documentation page](../../README.md#checking-the-solver-modules).
 
 As each solver is different, the solver wrappers are highly customized too. Nevertheless, they all inherit from
 the `SolverWrapper` class, which inherits from the `Component` class, and must all implement the following
-methods: `initialize`, `initialize_solution_step`, `solve_solution_step`, `finalize_solution_step`, `finalize`.
+methods: `initialize`, `initialize_solution_step`, `solve_solution_step`, `finalize_solution_step`, 
+`output_solution_step` and `finalize`.
 
 Upon instantiation of the solver wrapper object, the solver wrapper has to create a `Model` containing one or
 more `ModelParts` which correspond to (a part of) the fluid-structure interface. The interface coordinates at time step

--- a/tools.py
+++ b/tools.py
@@ -233,6 +233,20 @@ def time_solve_solution_step(solve_solution_step):
     return wrapper
 
 
+# save time measuring function
+def time_save(output_solution_step):
+    def wrapper(*args):
+        self = args[0]
+        if not hasattr(self, 'save_time'):
+            self.save_time = 0.0
+        start_time = time.time()
+        interface_output = output_solution_step(*args)
+        self.save_time += time.time() - start_time
+        return interface_output
+
+    return wrapper
+
+
 # pass on parameters
 def pass_on_parameters(settings_from, settings_to, keys):
     for key in keys:


### PR DESCRIPTION
**Description** Next to the time required for initialization, the run time is reported by CoCoNuT. New is that within the run time, the time required to save data is reported separately. Before, this was included in the coupling time. By making the time required to save data explicit, it can be better decided what amount of data is appropriate to save or how often data is saved.

**Users' experience affected?** The `time allocation` field in the `pickle file` has changed slightly.

**Other parts of the code affected?** The part of the `solver wrappers` where data is stored has been moved into the method `output_solution_step`.

**Tests** The fast test suite has been run.

**Related issues** Closes #221 

**Checklist**
- [x] Style guidelines
    1. CoCoNuT follows [the PEP8 style guide](https://www.python.org/dev/peps/pep-0008/).
    2. Comments should be lowercase.
    3. Errors should start with capitals, preferably without punctuation unless it's multiple sentences.
    4. Strings should use single quotes whenever possible.	
- [x] Self-review of code performed
- [x] Code has been commented (particularly in hard-to-understand areas)
- [x] Documentation was updated correspondingly
- [x] New and existing unit tests pass locally with changes
