### PR TITLE
Fix performance issue on HPC

### DIFF
--- a/example_job_script.pbs
+++ b/example_job_script.pbs
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+#PBS -N example_lid_driven_cavity
+#PBS -l walltime=00:59:00
+#PBS -l nodes=1:ppn=all
+#
+
+ml Anaconda3
+export PYTHONPATH=$HOME/Tools/coconut/:$PYTHONPATH
+export PYTHONPATH=$HOME/Tools/Kratos/lib/python3.10/site-packages/:$PYTHONPATH
+
+export OMP_PROC_BIND=FALSE # required on UGent-HPC for processes spawned from Python
+
+cd $HOME/Tools/coconut/coconut/examples/lid_driven_cavity/fluent2d_kratos_structure2d/
+python3 setup_case.py
+python3 run_simulation.py
+

--- a/solver_modules.py
+++ b/solver_modules.py
@@ -5,7 +5,7 @@ uses the environment variables in all the spawned processes, used for executing 
 in the various stages of the simulation.
 """
 
-machine_name = 'ugent_cluster_CO7'
+machine_name = 'hortense'
 
 solver_load_cmd_dict = {
     'ugent_cluster_CO7': {
@@ -22,14 +22,14 @@ solver_load_cmd_dict = {
         'fluent.v2019R3': 'ml FLUENT/2019R3 && ml intel/2020a && unset SLURM_GTIDS '
                           '&& export ANSYSLI_SERVERS=2325@ir03lic1.ugent.be '
                           '&& export ANSYSLMD_LICENSE_FILE=1055@ir03lic1.ugent.be && cat $PBS_NODEFILE > fluent.hosts',
-        'fluent.v2023R1': 'ml FLUENT/2023R1 && ml iimpi/2022b && unset SLURM_GTIDS '
+        'fluent.v2023R1': 'ml FLUENT/2023R1 && ml iimpi/2023a && unset SLURM_GTIDS '
                           '&& export ANSYSLI_SERVERS=2325@ir03lic1.ugent.be '
                           '&& export ANSYSLMD_LICENSE_FILE=1055@ir03lic1.ugent.be && cat $PBS_NODEFILE > fluent.hosts',
         'abaqus.v2021': 'ml intel/2021b && ml ABAQUS/2021-hotfix-2132 '
                         '&& export LM_LICENSE_FILE=@ir03lic1.ugent.be:27000@ea11serv03.private.ugent.be',
         'abaqus.v2022': 'ml intel/2022a && ml ABAQUS/2022-hotfix-2214 '
                         '&& export LM_LICENSE_FILE=@ir03lic1.ugent.be:27000@ea11serv03.private.ugent.be',
-        'kratos_structure.v94': '',
+        'kratos_structure.v94': 'export OMP_PROC_BIND=TRUE ',
         'openfoam.v8': 'ml OpenFOAM/8-foss-2020b && source $FOAM_BASH'
     },
     'hortense': {
@@ -44,6 +44,7 @@ solver_load_cmd_dict = {
                           '&& export ANSYSLMD_LICENSE_FILE=1055@ir03lic1.ugent.be && cat $PBS_NODEFILE > fluent.hosts',
         'abaqus.v2022': 'ml intel/2021a && module load ABAQUS/2022 '
                         '&& export LM_LICENSE_FILE=@ir03lic1.ugent.be:27000@ea11serv03.private.ugent.be',
+        'kratos_structure.v94': 'export OMP_PROC_BIND=TRUE ',
         'openfoam.v8': 'ml OpenFOAM/8-foss-2020b && source $FOAM_BASH'
     }
 }

--- a/solver_modules.py
+++ b/solver_modules.py
@@ -29,7 +29,7 @@ solver_load_cmd_dict = {
                         '&& export LM_LICENSE_FILE=@ir03lic1.ugent.be:27000@ea11serv03.private.ugent.be',
         'abaqus.v2022': 'ml intel/2022a && ml ABAQUS/2022-hotfix-2214 '
                         '&& export LM_LICENSE_FILE=@ir03lic1.ugent.be:27000@ea11serv03.private.ugent.be',
-        'kratos_structure.v94': 'export OMP_PROC_BIND=TRUE ',
+        'kratos_structure.v94': 'export OMP_PROC_BIND=TRUE ',  # needs to be FALSE in job script, but TRUE for Kratos
         'openfoam.v8': 'ml OpenFOAM/8-foss-2020b && source $FOAM_BASH'
     },
     'hortense': {
@@ -44,7 +44,7 @@ solver_load_cmd_dict = {
                           '&& export ANSYSLMD_LICENSE_FILE=1055@ir03lic1.ugent.be && cat $PBS_NODEFILE > fluent.hosts',
         'abaqus.v2022': 'ml intel/2021a && module load ABAQUS/2022 '
                         '&& export LM_LICENSE_FILE=@ir03lic1.ugent.be:27000@ea11serv03.private.ugent.be',
-        'kratos_structure.v94': 'export OMP_PROC_BIND=TRUE ',
+        'kratos_structure.v94': 'export OMP_PROC_BIND=TRUE ',  # needs to be FALSE in job script, but TRUE for Kratos
         'openfoam.v8': 'ml OpenFOAM/8-foss-2020b && source $FOAM_BASH'
     }
 }

--- a/solver_modules.py
+++ b/solver_modules.py
@@ -5,7 +5,7 @@ uses the environment variables in all the spawned processes, used for executing 
 in the various stages of the simulation.
 """
 
-machine_name = 'hortense'
+machine_name = 'ugent_cluster_CO7'
 
 solver_load_cmd_dict = {
     'ugent_cluster_CO7': {


### PR DESCRIPTION
**Description** When running the Python tests for the Fluent solver wrapper there was a significant slow down for tests later in the sequence. It is required to `export OMP_PROC_BIND=FALSE` in the HPC job-script. This avoids the processes spawned from Python are pinned to the same core. For Kratos however, it must be put on `TRUE` (see https://github.com/KratosMultiphysics/Kratos/issues/369#issuecomment-300436835). This can be done from the `solver_modules.py`, as the Kratos-Python process runs in a seperate environment.
https://github.com/pyfsi/coconut/blob/59e76c4327e47c66dcce91ffb1a3620adc10f356/coupling_components/solver_wrappers/kratos_structure/kratos_structure.py#L69-L70

An example job-script was added and `solver_modules.py` was adjusted so that the performance of Kratos is not affected by this setting.

**Users' experience affected?** No.

**Other parts of the code affected?** No.

**Tests** Tests run well on the UGent Tier-2 (tested skitty and doduo) and Tier-1 Hortense (tested dodrio/cpu_milan). Jobscript example was tested on Tier-2 (skitty).

**Related issues** No.

**Checklist**
- [X] Style guidelines
- [X] Self-review of code performed
- [X] Code has been commented (particularly in hard-to-understand areas)
- [X] Documentation was updated correspondingly
- [X] New and existing unit tests pass locally with changes
