### PR TITLE
Make make_inp.py compatible with both Abaqus 2023 and 2024

### DIFF
--- a/examples/tube/setup_files/abaqus2d/make_inp.py
+++ b/examples/tube/setup_files/abaqus2d/make_inp.py
@@ -10,17 +10,21 @@ from job import *
 from sketch import *
 from visualization import *
 from connectorBehavior import *
-import importlib.util
-import sys
 
-coconut_path = importlib.util.find_spec('coconut').submodule_search_locations[0]
-spec = importlib.util.spec_from_file_location('make_surface',
-                                              coconut_path +
-                                              '/coupling_components/solver_wrappers/abaqus/extra/make_surface.py')
-module = importlib.util.module_from_spec(spec)
-sys.modules['make_surface'] = module
-spec.loader.exec_module(module)
-from make_surface import *
+import sys
+if sys.version_info[0] == 2:
+    # Abaqus 2023 and older work with Python 2.7; this version can't work with the symbols in the CoCoNuT logo
+    # Therefore, make_surface has to be imported as a stand-alone module
+    import imp
+
+    coconut_path = imp.find_module('coconut')[1]
+    fp, path_name, description = imp.find_module('make_surface',
+                                                 [coconut_path + '/coupling_components/solver_wrappers/abaqus/extra/'])
+    imp.load_module('make_surface', fp, path_name, description)
+    from make_surface import *
+else:
+    # Abaqus 2024 and newer work with Python 3.10; a normal import is possible
+    from coconut.coupling_components.solver_wrappers.abaqus.extra.make_surface import *
 
 mdb = Mdb(pathName='case_tube2d.cae')
 tubeModel = mdb.ModelFromInputFile(name='Model-1', inputFileName='mesh_tube2d.inp')


### PR DESCRIPTION
**Description** Abaqus 2023 and older use Python 2.7, while Abaqus 2024 uses Python 3.10. This required an update of some Python files. The file to setup Abaqus cases in the examples (make_inp.py) has now been made compatible with both Abaqus 2023 and 2024.

**Users' experience affected?** No

**Other parts of the code affected?** No

**Tests** The setup works successfully with both versions.

**Related issues** Not applicable

**Checklist**
- [x] Style guidelines
    1. CoCoNuT follows [the PEP8 style guide](https://www.python.org/dev/peps/pep-0008/).
    2. Comments should be lowercase.
    3. Errors should start with capitals, preferably without punctuation unless it's multiple sentences.
    4. Strings should use single quotes whenever possible.	
- [x] Self-review of code performed
- [x] Code has been commented (particularly in hard-to-understand areas)
- [x] Documentation was updated correspondingly
- [x] New and existing unit tests pass locally with changes
