### PR TITLE
Update solver load commands for UGent HPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Since `machine_name` is set to `ugent_cluster_CO7`, this dictionary is used by d
 In case your system differs from the `ugent_cluster_CO7` settings, it is advised to add your own internal dictionary to `solver_load_cmd_dict` and provide this key to `machine_name`.
 If a solver module is not present on your system the key should be removed. If a solver module is always present, i.e. no module load command or similar action is needed, an empty string should be given as value.
 When CoCoNuT tries to use a solver module that is not present in the `solver_load_cmd_dict` or that has the wrong value, an error will be raised.
+The standard output and error are redirected to a file named *`solver_load_cmd.log`*.
 
 ### Quick test
 

--- a/examples/breaking_dam/fluent2d_abaqus2d/setup_case.py
+++ b/examples/breaking_dam/fluent2d_abaqus2d/setup_case.py
@@ -5,7 +5,7 @@ from os.path import join
 
 from coconut import tools
 
-cfd_solver = 'fluent.v2024R1'
+cfd_solver = 'fluent.v2024R2'
 csm_solver = 'abaqus.v2024'
 cfd_dir = './CFD'
 csm_dir = './CSM'

--- a/examples/breaking_dam/fluent2d_kratos_structure2d/setup_case.py
+++ b/examples/breaking_dam/fluent2d_kratos_structure2d/setup_case.py
@@ -5,7 +5,7 @@ from os.path import join
 
 from coconut import tools
 
-cfd_solver = 'fluent.v2024R1'
+cfd_solver = 'fluent.v2024R2'
 csm_solver = 'kratos_structure.v94'
 cfd_dir = './CFD'
 csm_dir = './CSM'

--- a/examples/lid_driven_cavity/fluent2d_kratos_structure2d/setup_case.py
+++ b/examples/lid_driven_cavity/fluent2d_kratos_structure2d/setup_case.py
@@ -5,7 +5,7 @@ from os.path import join
 
 from coconut import tools
 
-cfd_solver = 'fluent.v2024R1'
+cfd_solver = 'fluent.v2024R2'
 csm_solver = 'kratos_structure.v94'
 cfd_dir = './CFD'
 csm_dir = './CSM'

--- a/examples/test_single_solver/setup_case.py
+++ b/examples/test_single_solver/setup_case.py
@@ -5,7 +5,7 @@ from os.path import join
 
 from coconut import tools
 
-cfd_solver = 'fluent.v2024R1'
+cfd_solver = 'fluent.v2024R2'
 csm_solver = 'abaqus.v2024'
 cfd_dir = './CFD'
 csm_dir = './CSM'

--- a/examples/tube/fluent2d_abaqus2d/setup_case.py
+++ b/examples/tube/fluent2d_abaqus2d/setup_case.py
@@ -5,7 +5,7 @@ from os.path import join
 
 from coconut import tools
 
-cfd_solver = 'fluent.v2024R1'
+cfd_solver = 'fluent.v2024R2'
 csm_solver = 'abaqus.v2024'
 cfd_dir = './CFD'
 csm_dir = './CSM'

--- a/examples/tube/fluent2d_abaqus2d_steady/setup_case.py
+++ b/examples/tube/fluent2d_abaqus2d_steady/setup_case.py
@@ -5,7 +5,7 @@ from os.path import join
 
 from coconut import tools
 
-cfd_solver = 'fluent.v2024R1'
+cfd_solver = 'fluent.v2024R2'
 csm_solver = 'abaqus.v2024'
 cfd_dir = './CFD'
 csm_dir = './CSM'

--- a/examples/tube/fluent2d_abaqus2d_surrogate/setup_case.py
+++ b/examples/tube/fluent2d_abaqus2d_surrogate/setup_case.py
@@ -4,7 +4,7 @@ import subprocess
 from os.path import join
 from coconut import tools
 
-cfd_solver = 'fluent.v2024R1'
+cfd_solver = 'fluent.v2024R2'
 csm_solver = 'abaqus.v2024'
 
 cfd_dir = './CFD'

--- a/examples/tube/fluent2d_tube_structure/setup_case.py
+++ b/examples/tube/fluent2d_tube_structure/setup_case.py
@@ -5,7 +5,7 @@ from os.path import join
 
 from coconut import tools
 
-cfd_solver = 'fluent.v2024R1'
+cfd_solver = 'fluent.v2024R2'
 cfd_dir = './CFD'
 csm_dir = './CSM'
 

--- a/examples/tube/fluent3d_abaqus2d/setup_case.py
+++ b/examples/tube/fluent3d_abaqus2d/setup_case.py
@@ -5,7 +5,7 @@ from os.path import join
 
 from coconut import tools
 
-cfd_solver = 'fluent.v2024R1'
+cfd_solver = 'fluent.v2024R2'
 csm_solver = 'abaqus.v2024'
 cfd_dir = './CFD'
 csm_dir = './CSM'

--- a/examples/tube/fluent3d_abaqus3d/setup_case.py
+++ b/examples/tube/fluent3d_abaqus3d/setup_case.py
@@ -5,7 +5,7 @@ from os.path import join
 
 from coconut import tools
 
-cfd_solver = 'fluent.v2024R1'
+cfd_solver = 'fluent.v2024R2'
 csm_solver = 'abaqus.v2024'
 cfd_dir = './CFD'
 csm_dir = './CSM'

--- a/examples/tube/fluent3d_kratos_structure3d/parameters.json
+++ b/examples/tube/fluent3d_kratos_structure3d/parameters.json
@@ -43,7 +43,7 @@
     },
     "solver_wrappers": [
       {
-        "type": "solver_wrappers.fluent.v2024R1",
+        "type": "solver_wrappers.fluent.v2024R2",
         "settings": {
           "working_directory": "CFD",
           "case_file": "case_tube3d.cas.h5",

--- a/examples/tube/fluent3d_kratos_structure3d/setup_case.py
+++ b/examples/tube/fluent3d_kratos_structure3d/setup_case.py
@@ -5,7 +5,7 @@ from os.path import join
 
 from coconut import tools
 
-cfd_solver = 'fluent.v2024R1'
+cfd_solver = 'fluent.v2024R2'
 csm_solver = 'kratos_structure.v94'
 cfd_dir = './CFD'
 csm_dir = './CSM'

--- a/examples/turek/fluent2d_abaqus2d/setup_case.py
+++ b/examples/turek/fluent2d_abaqus2d/setup_case.py
@@ -5,7 +5,7 @@ from os.path import join
 
 from coconut import tools
 
-cfd_solver = 'fluent.v2024R1'
+cfd_solver = 'fluent.v2024R2'
 csm_solver = 'abaqus.v2024'
 cfd_dir = './CFD'
 csm_dir = './CSM'

--- a/examples/turek/fluent2d_abaqus2d_steady/setup_case.py
+++ b/examples/turek/fluent2d_abaqus2d_steady/setup_case.py
@@ -5,7 +5,7 @@ from os.path import join
 
 from coconut import tools
 
-cfd_solver = 'fluent.v2024R1'
+cfd_solver = 'fluent.v2024R2'
 csm_solver = 'abaqus.v2024'
 cfd_dir = './CFD'
 csm_dir = './CSM'

--- a/solver_modules.py
+++ b/solver_modules.py
@@ -21,28 +21,28 @@ solver_load_cmd_dict = {
                         '&& export LM_LICENSE_FILE=@ir03lic1.ugent.be:27000@ea11serv03.private.ugent.be',
     },
     'ugent_hpc': {
-        'fluent.v2023R1': 'ml FLUENT/2023R1 && ml iimpi/2023a && unset SLURM_GTIDS '
+        'fluent.v2023R1': 'ml FLUENT/2023R1 ; ml iimpi/2023a ; unset SLURM_GTIDS '
                           '&& export ANSYSLI_SERVERS=2325@ir03lic1.ugent.be '
                           '&& export ANSYSLMD_LICENSE_FILE=1055@ir03lic1.ugent.be',
-        'fluent.v2024R1': 'ml FLUENT/2024R1 && unset SLURM_GTIDS '
+        'fluent.v2024R1': 'ml FLUENT/2024R1 ; unset SLURM_GTIDS '
                           '&& export ANSYSLI_SERVERS=2325@ir03lic1.ugent.be '
                           '&& export ANSYSLMD_LICENSE_FILE=1055@ir03lic1.ugent.be',
-        'fluent.v2024R2': 'ml FLUENT/2024R2 && unset SLURM_GTIDS '
+        'fluent.v2024R2': 'ml FLUENT/2024R2 ; unset SLURM_GTIDS '
                           '&& export ANSYSLI_SERVERS=2325@ir03lic1.ugent.be '
                           '&& export ANSYSLMD_LICENSE_FILE=1055@ir03lic1.ugent.be',
-        'abaqus.v2023': 'ml intel/2022b && ml ABAQUS/2023 '
-                        '&& export LM_LICENSE_FILE=@ir03lic1.ugent.be:27000@ea11serv03.private.ugent.be',
-        'abaqus.v2024': 'ml intel/2022b && ml ABAQUS/2024-hotfix-2405 '
-                        '&& export LM_LICENSE_FILE=@ir03lic1.ugent.be:27000@ea11serv03.private.ugent.be',
-        'kratos_structure.v94': 'export OMP_PROC_BIND=TRUE ',  # needs to be FALSE in job script, but TRUE for Kratos
-        'openfoam.v10': 'ml OpenFOAM/10-foss-2023a && source $FOAM_BASH',
-        'openfoam.v11': 'ml OpenFOAM/11-foss-2023a && source $FOAM_BASH'
+        'abaqus.v2023': 'ml intel/2022b ; ml ABAQUS/2023 '
+                        '; export LM_LICENSE_FILE=@ir03lic1.ugent.be:27000@ea11serv03.private.ugent.be',
+        'abaqus.v2024': 'ml intel/2022b ; ml ABAQUS/2024-hotfix-2405 '
+                        '; export LM_LICENSE_FILE=@ir03lic1.ugent.be:27000@ea11serv03.private.ugent.be',
+        'kratos_structure.v94': 'export OMP_PROC_BIND=TRUE',  # needs to be FALSE in job script, but TRUE for Kratos
+        'openfoam.v10': 'ml OpenFOAM/10-foss-2023a ; source $FOAM_BASH',
+        'openfoam.v11': 'ml OpenFOAM/11-foss-2023a ; source $FOAM_BASH'
     },
     'hortense': {
-        'fluent.v2023R1': 'ml FLUENT/2023R1 && ml intel/2021a '
-                          '&& export ANSYSLI_SERVERS=2325@ir03lic1.ugent.be '
+        'fluent.v2023R1': 'ml FLUENT/2023R1 ; ml intel/2021a '
+                          '; export ANSYSLI_SERVERS=2325@ir03lic1.ugent.be '
                           '&& export ANSYSLMD_LICENSE_FILE=1055@ir03lic1.ugent.be',
-        'kratos_structure.v94': 'export OMP_PROC_BIND=TRUE ',  # needs to be FALSE in job script, but TRUE for Kratos
+        'kratos_structure.v94': 'export OMP_PROC_BIND=TRUE',  # needs to be FALSE in job script, but TRUE for Kratos
     }
 }
 

--- a/tools.py
+++ b/tools.py
@@ -1,15 +1,15 @@
-from coconut import solver_modules
-
-import time
-from contextlib import contextmanager
-import numpy as np
-import warnings
-import os
-from os.path import join
-import subprocess
-import pickle
 import importlib.util
+import os
+import pickle
 import shutil
+import subprocess
+import time
+import warnings
+from contextlib import contextmanager
+from os.path import join
+
+import numpy as np
+from coconut import solver_modules
 
 
 def create_instance(settings, if_not_defined=None):
@@ -394,12 +394,14 @@ def get_solver_env(solver_module_name, working_dir):
         solver_load_cmd = 'echo'
 
     # run the module load command and store the environment
+    log_file_name = join(working_dir, 'solver_load_cmd.log')
     try:
-        subprocess.check_call(
-            f'{solver_load_cmd} && python3 -c "from coconut import tools;tools.write_env()"',
-            shell=True, cwd=working_dir, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        with open(log_file_name, 'w') as f:
+            subprocess.check_call(
+                f'{solver_load_cmd} && python3 -c "from coconut import tools ; tools.write_env()"',
+                shell=True, cwd=working_dir, stdout=f, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError:
-        raise RuntimeError(f'Module load command for solver wrapper {solver_name} failed.')
+        raise RuntimeError(f'Module load command for solver wrapper {solver_name} failed, see {log_file_name}')
 
     # load the environment variables and return as python-dict
     env_filepath = join(working_dir, env_filename)


### PR DESCRIPTION
**Description** `module load` or in short `ml `returns non-zero exit code when used in shell launched from Python on the UGent HPC.  Nevertheless, the solver environments are loaded successfully. To overcome that the solver load command fails `&&` is changed to `;` after the `ml` commands. (`&&` executes the next command only if the previous returned exit code 0, while `;` executes the next command regardless of the exit code of the previous command)

! Note that no Python error will be thrown when the `ml `command doesn't work properly on the UGent HPC!

This problem does not occur on our local system.

Additionally:

- A log of the solver load command is created (_`solver_load_cmd.log`_)
- The Fluent versions in the _`setup_case.py`_ scripts are updated

**Users' experience affected?** NA

**Other parts of the code affected?** NA

**Tests** The module load command on the HPC have been tested for one example.

**Related issues** NA

**Checklist**
- [x] Style guidelines
    1. CoCoNuT follows [the PEP8 style guide](https://www.python.org/dev/peps/pep-0008/).
    2. Comments should be lowercase.
    3. Errors should start with capitals, preferably without punctuation unless it's multiple sentences.
    4. Strings should use single quotes whenever possible.	
- [x] Self-review of code performed
- [x] Code has been commented (particularly in hard-to-understand areas)
- [x] Documentation was updated correspondingly
- [x] New and existing unit tests pass locally with changes
