### PR TITLE
Save x interface in one way coupled solver

### DIFF
--- a/coupling_components/coupled_solvers/one_way.py
+++ b/coupling_components/coupled_solvers/one_way.py
@@ -13,6 +13,6 @@ class CoupledSolverOneWay(CoupledSolver):
 
     def solve_solution_step(self):
         self.y = self.solver_wrappers[0].solve_solution_step(self.x.copy()).copy()
-        xt = self.solver_wrappers[1].solve_solution_step(self.y.copy())
+        self.x = xt = self.solver_wrappers[1].solve_solution_step(self.y.copy())
         r = xt - self.x
         self.finalize_iteration(r)

--- a/coupling_components/coupled_solvers/one_way.py
+++ b/coupling_components/coupled_solvers/one_way.py
@@ -12,7 +12,9 @@ class CoupledSolverOneWay(CoupledSolver):
         print_info('CoupledSolverOneWay is chosen: convergence criterion and predictor are ignored', layout='info')
 
     def solve_solution_step(self):
+        self.x *= 0  # set interface to zero: no effect of other solver
         self.y = self.solver_wrappers[0].solve_solution_step(self.x.copy()).copy()
-        self.x = xt = self.solver_wrappers[1].solve_solution_step(self.y.copy())
+        xt = self.solver_wrappers[1].solve_solution_step(self.y.copy())
         r = xt - self.x
+        self.x = xt  # for storing resulting interface
         self.finalize_iteration(r)


### PR DESCRIPTION
**Description** The one way coupled solver now stores the resulting _x-interface_ (usually displacement for an FSI calculation) in the pickle file.

**Users' experience affected?** Not applicable.

**Other parts of the code affected?** Not applicable.

**Tests** The corresponding tests still work.

**Related issues** Not applicable.

**Checklist**
- [x] Style guidelines
    1. CoCoNuT follows [the PEP8 style guide](https://www.python.org/dev/peps/pep-0008/).
    2. Comments should be lowercase.
    3. Errors should start with capitals, preferably without punctuation unless it's multiple sentences.
    4. Strings should use single quotes whenever possible.	
- [x] Self-review of code performed
- [x] Code has been commented (particularly in hard-to-understand areas)
- [x] Documentation was updated correspondingly
- [x] New and existing unit tests pass locally with changes
