### PR TITLE
Update check for Python version and docs

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -13,9 +13,9 @@ class Analysis:
         pass_on_parameters(self.settings, parameters['coupled_solver']['settings'],
                            ['timestep_start', 'number_of_timesteps', 'delta_t', 'save_restart'])
 
-        # Python version: 3.6 or higher
-        if sys.version_info < (3, 6):
-            raise RuntimeError('Python version 3.6 or higher required.')
+        # Python version: 3.11 or higher
+        if sys.version_info < (3, 11):
+            raise RuntimeError('Python version 3.11 or higher required.')
 
         self.coupled_solver = create_instance(self.parameters['coupled_solver'])
 

--- a/coupling_components/solver_wrappers/solver_wrappers.md
+++ b/coupling_components/solver_wrappers/solver_wrappers.md
@@ -28,13 +28,14 @@ coupled solver as an `Interface` object.
 
 There are currently two solver wrappers for computational fluid dynamics (CFD) packages:
 
-- [ANSYS Fluent](fluent/fluent.md) (2019R3, 2021R1, 2023R1)
-- [OpenFOAM](openfoam/openfoam.md) (8)
+- [ANSYS Fluent](fluent/fluent.md)
+- [OpenFOAM](openfoam/openfoam.md)
 
-There are currently also two solver wrappers for computational structural mechanics (CSM) packages :
+There are currently also three solver wrappers for computational structural mechanics (CSM) packages :
 
-- [Abaqus](abaqus/abaqus.md) (2021, 2022)
-- [Kratos Multiphysics](kratos_structure/kratos_structure.md) (9.1)
+- [Abaqus](abaqus/abaqus.md)
+- [AbaqusCSE](abaqus_cse/abaqus_cse.md)
+- [Kratos Multiphysics](kratos_structure/kratos_structure.md)
 
 CoCoNuT also implements several 1D Python-based solver wrappers to provide a fast and easy way to test new algorithms
 and implementations. These are:


### PR DESCRIPTION
**Description** The check for the Python version has been updated in *`analysis.py`* and the general documentation on the solver wrappers is updated as well.

**Users' experience affected?** An error is raised if the Python version is older than 3.11 (previously: 3.6)

**Other parts of the code affected?** N/A

**Tests** Ran the example `tube_flow_tube_ringmodel` with both Anaconda3/2020.11 (which raises the expected error) and Aanconda3/2024.02 (which doesn't)

**Related issues** N/A

**Checklist**
- [x] Style guidelines
    1. CoCoNuT follows [the PEP8 style guide](https://www.python.org/dev/peps/pep-0008/).
    2. Comments should be lowercase.
    3. Errors should start with capitals, preferably without punctuation unless it's multiple sentences.
    4. Strings should use single quotes whenever possible.	
- [x] Self-review of code performed
- [x] Code has been commented (particularly in hard-to-understand areas)
- [x] Documentation was updated correspondingly
- [x] New and existing unit tests pass locally with changes
